### PR TITLE
feat: add support for custom resolve fn (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can use a domain name or an email address as the target, for additional conf
     -   **ignoreIPv6** (boolean, defaults to `false`) If true then never use IPv6 addresses for sending
     -   **preferIPv6** (boolean, defaults to `false`) If true then use IPv6 address even if IPv4 address is also available
     -   **blockLocalAddresses** (boolean, defaults to `false`) If true then refuses to connect to IP addresses that are either in loopback, private network or attached to the server. People put every kind of stuff in MX records, you do not want to flood your loopback interface because someone thought it is a great idea to set 127.0.0.1 as the MX server
+    -   **resolve** (function, defaults to `dns.resolve`, callback-style)
 -   **mx** is a resolved MX object or an array of MX objects to skip DNS resolving. Useful if you want to connect to a specific host.
     -   **exchange** is the hostname of the MX
     -   **priority** (defaults to 0) is the MX priority number that is used to sort available MX servers (servers with higher priority are tried first)

--- a/lib/mx-connect.js
+++ b/lib/mx-connect.js
@@ -5,6 +5,7 @@ const resolveMX = require('./resolve-mx');
 const resolveIP = require('./resolve-ip');
 const getConnection = require('./get-connection');
 const net = require('net');
+const dns = require('dns');
 
 module.exports = (options, callback) => {
     if (typeof options === 'string') {
@@ -34,7 +35,8 @@ module.exports = (options, callback) => {
         dnsOptions: options.dnsOptions || {
             ignoreIPv6: false,
             preferIPv6: false,
-            blockLocalAddresses: false
+            blockLocalAddresses: false,
+            resolve: dns.resolve
         },
 
         port: options.port || 25,

--- a/lib/resolve-ip.js
+++ b/lib/resolve-ip.js
@@ -6,9 +6,9 @@ const dnsErrors = require('./dns-errors');
 const tools = require('./tools');
 
 // we do not reject on error to avoid issues where one failing MX record kills entire sending
-function resolve4(mx) {
+function resolve4(mx, dnsResolve = dns.resolve) {
     return new Promise(resolve => {
-        dns.resolve4(mx.exchange, (err, list) => {
+        dnsResolve(mx.exchange, (err, list) => {
             if (err && err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
                 mx.A = [].concat({ error: err, exchange: mx.exchange });
             } else {
@@ -19,9 +19,9 @@ function resolve4(mx) {
     });
 }
 
-function resolve6(mx) {
+function resolve6(mx, dnsResolve = dns.resolve) {
     return new Promise(resolve => {
-        dns.resolve6(mx.exchange, (err, list) => {
+        dnsResolve(mx.exchange, 'AAAA', (err, list) => {
             if (err && err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
                 mx.AAAA = [].concat({ error: err, exchange: mx.exchange });
             } else {
@@ -80,9 +80,9 @@ function resolveIP(delivery) {
         delivery.mx.forEach(entry => {
             if (entry.exchange) {
                 if (!net.isIP(entry.exchange)) {
-                    resolveAddresses.push(resolve4(entry));
+                    resolveAddresses.push(resolve4(entry, dnsOptions.resolve));
                     if (!dnsOptions.ignoreIPv6) {
-                        resolveAddresses.push(resolve6(entry));
+                        resolveAddresses.push(resolve6(entry, dnsOptions.resolve));
                     }
                 } else if (net.isIPv4(entry.exchange)) {
                     entry.A = [].concat(entry.exchange || []);

--- a/lib/resolve-mx.js
+++ b/lib/resolve-mx.js
@@ -10,7 +10,8 @@ function resolveMX(delivery) {
         let firstError = false;
         let addressFound = false;
         let dnsOptions = delivery.dnsOptions || {
-            ignoreIPv6: false
+            ignoreIPv6: false,
+            resolve: dns.resolve
         };
 
         let filterAddress = ip => {
@@ -52,7 +53,7 @@ function resolveMX(delivery) {
 
         let domain = delivery.decodedDomain;
 
-        dns.resolveMx(domain, (err, list) => {
+        dnsOptions.resolve(domain, 'MX', (err, list) => {
             if (err && err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
                 err.category = 'dns';
                 err.message = 'DNS error when resolving MX server for ' + domain + ': ' + (dnsErrors[err.code] || err.message);
@@ -63,7 +64,7 @@ function resolveMX(delivery) {
 
             if (!list || !list.length) {
                 // fallback to A
-                return dns.resolve4(domain, (err, list) => {
+                return dnsOptions.resolve(domain, (err, list) => {
                     if (err && err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
                         err.message = 'DNS error when resolving MX server for ' + domain + ': ' + (dnsErrors[err.code] || err.message);
                         err.response = '450 ' + err.message;
@@ -73,7 +74,7 @@ function resolveMX(delivery) {
 
                     if (!list || (!list.length && !dnsOptions.ignoreIPv6)) {
                         // fallback to AAAA
-                        return dns.resolve6(domain, (err, list) => {
+                        return dnsOptions.resolve(domain, 'AAAA', (err, list) => {
                             if (err && err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
                                 err.message = 'DNS error when resolving MX server for ' + domain + ': ' + (dnsErrors[err.code] || err.message);
                                 err.response = '450 ' + err.message;


### PR DESCRIPTION
@andris9 hey 👋! Just added this - it's backwards compatible and simply uses callback style to match existing behavior.  It's a v1 so at least we have something to solve #3 for now without a major package rewrite to use promises.  Feel free to author yourself using this commit or merge, either way works.   I couldn't get the tests to run (they kept timing out due to arbitrary connections in the tests) but it seems to work locally for me.  Ping us back if you merge this and release to npm, thanks!