### PR TITLE
fix(dane): harden DNS error handling, pass cert chain, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can use a domain name or an email address as the target, for additional conf
     - **resolveTlsa(tlsaName)** - custom async function to resolve TLSA records. Receives the full TLSA query name (e.g., `_25._tcp.mail.example.com`). If not provided, uses native `dns.resolveTlsa` when available
     - **checkDnssecSecure(hostname)** - optional async function to check DNSSEC validation status of an MX host before attempting TLSA lookups ([RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2)). Should return `{ secure: boolean }`. When provided and the zone is insecure, TLSA lookups are skipped and the connection falls back to opportunistic TLS. See [DNSSEC-Aware DANE](#dnssec-aware-dane) below
     - **logger(logObj)** - method to log DANE information, logging is disabled by default
-    - **verify** - if `true` (default), enforces DANE verification and rejects connections that fail. If `false`, only logs failures
+    - **verify** - *(deprecated, ignored)* DANE verification is always enforced when TLSA records are present, per RFC 7672. This option is accepted for backward compatibility but has no effect
 
 ### Connection object
 
@@ -215,17 +215,17 @@ const connection = await mxConnect({
 });
 ```
 
-When `checkDnssecSecure` reports that a zone is insecure, mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error, the zone is assumed insecure (safe default). If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
+When `checkDnssecSecure` reports that a zone is insecure (`{ secure: false }`), mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error (e.g. DNS timeout), the MX is marked as having a DANE lookup failure and the connection is rejected with a temporary error, preserving DANE enforcement across retries. If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
 
 ### DANE Verification Flow
 
 When DANE is enabled, the following flow occurs:
 
-1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones skip directly to step 5
+1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones (`{ secure: false }`) skip directly to step 5. If the check itself fails (DNS error), the MX is marked as a DANE lookup failure and the connection is rejected with a temporary error
 2. **TLSA Lookup**: For hosts in DNSSEC-signed zones (or when `checkDnssecSecure` is not provided), mx-connect resolves TLSA records for each MX hostname (e.g., `_25._tcp.mail.example.com`)
 3. **Connection**: A TCP connection is established to the MX server
-4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option
-5. **Certificate Verification**: The server's certificate is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
+4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option. Pass the certificate chain (from `socket.getPeerCertificate(true)`) as the third argument for DANE-TA/PKIX-TA support
+5. **Certificate Verification**: The server's certificate (and chain, if provided) is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
 
 ### TLSA Record Format
 
@@ -245,12 +245,12 @@ TLSA records returned by the resolver should have the following structure:
 
 | Usage | Name    | Description                                             | Support Status |
 | ----- | ------- | ------------------------------------------------------- | -------------- |
-| 0     | PKIX-TA | CA constraint - must chain to specified CA              | ⚠️ Limited\*   |
+| 0     | PKIX-TA | CA constraint - must chain to specified CA              | ✅ Full\*       |
 | 1     | PKIX-EE | Service certificate constraint - must match exactly     | ✅ Full        |
-| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | ⚠️ Limited\*   |
+| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | ✅ Full\*       |
 | 3     | DANE-EE | Domain-issued certificate - certificate must match      | ✅ Full        |
 
-> **\*Note on DANE-TA and PKIX-TA**: These usage types require access to the full certificate chain, which is not available in the standard TLS `checkServerIdentity` callback. Currently, only the end-entity (leaf) certificate is verified. If the TLSA record matches the end-entity certificate, verification will succeed; otherwise, it will fail even if the record matches a CA certificate in the chain. For most SMTP deployments, DANE-EE (usage=3) is recommended as it provides the strongest security guarantees and is fully supported.
+> **\*Note on DANE-TA and PKIX-TA**: These usage types require access to the full certificate chain. The `createDaneVerifier` function returned by this module accepts an optional `chain` parameter (an array of `X509Certificate` objects) that enables DANE-TA and PKIX-TA verification against CA certificates in the chain. When the chain is not provided, only the end-entity (leaf) certificate is verified and DANE-TA/PKIX-TA records will fail to match. For most SMTP deployments, DANE-EE (usage=3) is recommended as it provides the strongest security guarantees.
 
 ### Combining DANE with MTA-STS
 
@@ -287,8 +287,8 @@ console.log('DANE Usage Types:', dane.DANE_USAGE);
 console.log('DANE Selectors:', dane.DANE_SELECTOR);
 console.log('DANE Matching Types:', dane.DANE_MATCHING_TYPE);
 
-// Verify a certificate against TLSA records
-const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords);
+// Verify a certificate against TLSA records (with optional chain for DANE-TA)
+const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords, chain);
 ```
 
 ## License

--- a/lib/dane.js
+++ b/lib/dane.js
@@ -362,23 +362,29 @@ function daneError(message, code) {
  * Create a TLS verification function for DANE
  * @param {Array} tlsaRecords - Array of TLSA records
  * @param {Object} options - DANE options
- * @returns {Function} TLS checkServerIdentity function
+ * @returns {Function} checkServerIdentity(hostname, cert, chain) - Returns undefined on
+ *   success or an Error on failure. The optional `chain` parameter is an array of
+ *   X509Certificate objects representing the issuer chain, required for DANE-TA (usage 2)
+ *   and PKIX-TA (usage 0) verification.
  */
 function createDaneVerifier(tlsaRecords, options) {
-    return function checkServerIdentity(hostname, cert) {
+    return function checkServerIdentity(hostname, cert, chain) {
         if (!tlsaRecords || tlsaRecords.length === 0) {
             return undefined;
         }
 
         try {
-            const result = verifyCertAgainstTlsa(cert, tlsaRecords);
+            const result = verifyCertAgainstTlsa(cert, tlsaRecords, chain);
 
             if (!result.valid && !result.noRecords) {
                 logDane(options, { msg: 'DANE verification failed', success: false, hostname, error: result.error });
-
-                if (options.verify !== false) {
-                    return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
-                }
+                //
+                // RFC 7672 Section 2.2: DANE verification failures MUST be
+                // treated as fatal when usable TLSA records are present.
+                // There is no opt-out — once DANE is enabled the verifier
+                // always returns an error on mismatch.
+                //
+                return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
             }
 
             if (result.valid && result.matchedRecord) {
@@ -399,11 +405,7 @@ function createDaneVerifier(tlsaRecords, options) {
         } catch (err) {
             logDane(options, { msg: 'DANE verification error', success: false, hostname, error: err.message });
 
-            if (options.verify !== false) {
-                return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
-            }
-
-            return undefined;
+            return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
         }
     };
 }

--- a/lib/get-connection.js
+++ b/lib/get-connection.js
@@ -305,8 +305,8 @@ function tryConnect(delivery, mx) {
         return Promise.resolve(policyFailure);
     }
 
-    // Check for DANE lookup failures in verify mode
-    if (delivery.dane && delivery.dane.enabled && mx.daneLookupFailed && delivery.dane.verify !== false) {
+    // Check for DANE lookup failures (DNSSEC check or TLSA resolution failed)
+    if (delivery.dane && delivery.dane.enabled && mx.daneLookupFailed) {
         const errMsg = (mx.daneLookupError && mx.daneLookupError.message) || 'unknown error';
         const error = new Error(`DANE TLSA lookup failed for ${mx.hostname}: ${errMsg}`);
         error.response = `DANE error: ${error.message}`;

--- a/lib/mx-connect.js
+++ b/lib/mx-connect.js
@@ -113,6 +113,7 @@ async function validateMxPolicy(delivery) {
  * @param {string} hostname - The MX hostname to check
  * @param {Function|null} logger - Optional DANE logger
  * @returns {Promise<boolean>} True if the zone is DNSSEC-signed
+ * @throws {Error} If the DNSSEC check itself fails (DNS timeout, SERVFAIL, etc.)
  * @private
  */
 async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
@@ -120,12 +121,20 @@ async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
         const result = await checkDnssecSecure(hostname);
         return Boolean(result && result.secure);
     } catch (err) {
-        // If the DNSSEC check itself fails, log it and assume insecure.
-        // This is the safe default: skipping TLSA lookups for a zone we
-        // cannot confirm is signed avoids SERVFAIL-induced delivery failures.
+        //
+        // RFC 7672 Section 2.2: A DNS lookup failure (timeout, SERVFAIL)
+        // is NOT the same as an "insecure" response.  Returning false here
+        // would silently skip the TLSA lookup and bypass DANE entirely on
+        // transient DNS errors (e.g. DoH rate-limit on a queue retry).
+        //
+        // Instead, re-throw so that `resolveDaneTlsa` can mark the MX as
+        // having a DANE lookup failure (`mx.daneLookupFailed = true`).
+        // The connection layer will then reject with a temporary error,
+        // preserving DANE enforcement across retries.
+        //
         if (logger) {
             logger({
-                msg: 'DNSSEC status check failed, assuming insecure',
+                msg: 'DNSSEC status check failed, treating as lookup failure',
                 action: 'dane',
                 success: false,
                 hostname,
@@ -133,7 +142,7 @@ async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
                 code: err.code
             });
         }
-        return false;
+        throw err;
     }
 }
 
@@ -177,29 +186,36 @@ async function resolveDaneTlsa(delivery) {
         //  the first query response is 'insecure' [...], the SMTP client
         //  SHOULD NOT proceed to search for any associated TLSA records."
         //
-        if (typeof delivery.dane.checkDnssecSecure === 'function') {
-            const secure = await isZoneDnssecSecure(
-                delivery.dane.checkDnssecSecure,
-                mx.exchange,
-                delivery.dane.logger
-            );
-
-            if (!secure) {
-                mx.tlsaRecords = [];
-                if (delivery.dane.logger) {
-                    delivery.dane.logger({
-                        msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
-                        action: 'dane',
-                        success: true,
-                        hostname: mx.exchange,
-                        domain: delivery.domain
-                    });
-                }
-                return;
-            }
-        }
-
+        //
+        // DNSSEC check and TLSA resolution are wrapped in a single
+        // try/catch so that transient DNS failures in either step
+        // are handled uniformly: the MX is marked as having a DANE
+        // lookup failure and the connection layer rejects with a
+        // temporary error (preserving DANE enforcement on retries).
+        //
         try {
+            if (typeof delivery.dane.checkDnssecSecure === 'function') {
+                const secure = await isZoneDnssecSecure(
+                    delivery.dane.checkDnssecSecure,
+                    mx.exchange,
+                    delivery.dane.logger
+                );
+
+                if (!secure) {
+                    mx.tlsaRecords = [];
+                    if (delivery.dane.logger) {
+                        delivery.dane.logger({
+                            msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
+                            action: 'dane',
+                            success: true,
+                            hostname: mx.exchange,
+                            domain: delivery.domain
+                        });
+                    }
+                    return;
+                }
+            }
+
             mx.tlsaRecords = await dane.resolveTlsaRecords(mx.exchange, port, delivery.dane);
 
             if (mx.tlsaRecords.length > 0 && delivery.dane.logger) {
@@ -213,14 +229,14 @@ async function resolveDaneTlsa(delivery) {
                 });
             }
         } catch (err) {
-            // DNS errors (SERVFAIL, timeout) should not silently bypass DANE
-            // when verify mode is enabled. NODATA/NXDOMAIN are acceptable (no DANE records).
+            // DNS errors (SERVFAIL, timeout) should not silently bypass DANE.
+            // NODATA/NXDOMAIN are acceptable (no DANE records).
             mx.tlsaRecords = [];
             const isNoRecords = dane.isNoRecordsError(err.code);
 
             if (delivery.dane.logger) {
                 delivery.dane.logger({
-                    msg: 'TLSA lookup failed',
+                    msg: 'DANE DNS lookup failed',
                     action: 'dane',
                     success: false,
                     hostname: mx.exchange,
@@ -231,9 +247,10 @@ async function resolveDaneTlsa(delivery) {
                 });
             }
 
-            // If verify is enabled and this is a real DNS failure (not just "no records"),
-            // mark the MX as having a DANE lookup failure so connection can handle it
-            if (delivery.dane.verify !== false && !isNoRecords) {
+            // If this is a real DNS failure (not just "no records"),
+            // mark the MX as having a DANE lookup failure so connection can handle it.
+            // This covers both DNSSEC check failures and TLSA resolution failures.
+            if (!isNoRecords) {
                 mx.daneLookupFailed = true;
                 mx.daneLookupError = err;
             }
@@ -352,7 +369,9 @@ function buildDeliveryObject(options) {
         // Signature: async (hostname) => { secure: boolean }
         checkDnssecSecure: daneOptions.checkDnssecSecure || null,
         logger: daneOptions.logger || null,
-        verify: daneOptions.verify !== undefined ? daneOptions.verify : true
+        // NOTE: verify is always true — DANE enforcement is mandatory per RFC 7672.
+        // The option is accepted for backward compatibility but has no effect.
+        verify: true
     };
 
     return {
@@ -483,7 +502,7 @@ function buildPipeline(delivery) {
  *   DNSSEC status of MX host. Signature: async (hostname) => { secure: boolean }.
  *   When provided and the zone is insecure, TLSA lookups are skipped.
  * @param {Function} [options.dane.logger] - DANE event logger
- * @param {boolean} [options.dane.verify=true] - Enforce DANE verification (reject on failure)
+ * @param {boolean} [options.dane.verify=true] - Deprecated, ignored. DANE verification is always enforced per RFC 7672
  * @param {Function} [callback] - Node.js-style callback: (err, connection)
  * @returns {Promise<Object>} Connection result with socket and metadata
  * @returns {net.Socket} returns.socket - Connected TCP socket


### PR DESCRIPTION
Three critical fixes to prevent DANE bypass on retry and enable full DANE-TA verification:

1.  **isZoneDnssecSecure now throws on DNS errors.** Previously it returned `false`, which caused the TLSA lookup to be silently skipped on transient DNS failures (e.g. DoH rate-limit on retry). This was the root cause of the DANE bypass on queue retry. The thrown error is now caught by `resolveDaneTlsa` and marks the MX as having a DANE lookup failure, preserving enforcement.

2.  **createDaneVerifier now accepts a certificate chain.** The `checkServerIdentity(hostname, cert, chain)` signature passes the chain to `verifyCertAgainstTlsa`, enabling DANE-TA (usage 2) and PKIX-TA (usage 0) verification against CA certs.

3.  **Removed `options.verify` bypass.** DANE verification failures are now always fatal when TLSA records are present (RFC 7672). The `verify` option is accepted for backward compat but ignored. All `verify !== false` conditionals have been simplified.

Documentation updated:
- README: verify option marked deprecated, checkDnssecSecure throw behavior documented, DANE-TA/PKIX-TA marked as fully supported, verification flow updated with chain passing and DNS error handling
- JSDoc: isZoneDnssecSecure @throws added, createDaneVerifier return signature updated, verify param marked deprecated