### PR TITLE
feat: harden MX IP validation and reject null MX (RFC 7505)

### DIFF
--- a/lib/resolve-mx.js
+++ b/lib/resolve-mx.js
@@ -38,6 +38,47 @@ function createDnsError(err, domain, defaultMessage) {
 }
 
 /**
+ * Detects an RFC 7505 "null MX" record.
+ *
+ * A domain that does not accept mail publishes a single MX RR with preference 0 and a root
+ * exchange ("0 ."). Node's resolver (dns.resolveMx, via c-ares) returns that root as an
+ * empty string (verified: example.com -> exchange ""), which is the form seen in practice.
+ * mx-connect also accepts a custom dnsOptions.resolve whose output is not guaranteed to
+ * match c-ares, so the literal "." (the canonical root form) is normalized to a null MX
+ * as well.
+ *
+ * @param {Object} entry - An MX record ({ exchange, priority })
+ * @returns {boolean} True if the record is a null MX
+ * @private
+ */
+function isNullMx(entry) {
+    if (!entry) {
+        return false;
+    }
+    const exchange = (entry.exchange || '').trim();
+    return exchange === '' || exchange === '.';
+}
+
+/**
+ * Creates a permanent error for an RFC 7505 null MX domain.
+ *
+ * Null MX is an explicit, authoritative statement that the domain accepts no mail, so the
+ * error is permanent (temporary is left falsy) - it must never be deferred/retried. The
+ * category is 'dns' so downstream MTAs classify it alongside other resolution failures.
+ *
+ * @param {string} domain - The domain that published the null MX
+ * @returns {Error} Standardized permanent error
+ * @private
+ */
+function createNullMxError(domain) {
+    const error = new Error(`The recipient domain (${domain}) does not accept email; it publishes a null MX record (RFC 7505).`);
+    error.response = `DNS Error: ${error.message}`;
+    error.code = 'ENULLMX';
+    error.category = 'dns';
+    return error;
+}
+
+/**
  * Determines if a DNS error is recoverable (safe to try fallback record types).
  *
  * Returns true if:
@@ -152,6 +193,12 @@ async function resolveMX(delivery) {
     // Step 1: Try MX records (canonical mail server entries)
     const mxResult = await tryResolve(dnsResolve, domain, 'MX');
     if (mxResult.list.length) {
+        // RFC 7505 null MX: a "0 ." record signals the domain accepts no mail. Fail
+        // permanently instead of treating "." as a hostname (which would otherwise fail
+        // as a confusing resolution error) and do NOT fall back to A/AAAA records.
+        if (mxResult.list.some(isNullMx)) {
+            throw createNullMxError(domain);
+        }
         // Sort by priority (lower number = higher priority) per RFC 5321
         delivery.mx = mxResult.list
             .slice()

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -122,12 +122,34 @@ function isLocal(address) {
     return LOCAL_ADDRESSES.has(address);
 }
 
+// Ranges that are never valid unicast destinations for an outbound SMTP connection.
+// Rejected regardless of any option: unspecified (0.0.0.0), the limited broadcast address
+// (255.255.255.255), and multicast (224.0.0.0/4, ff00::/8) - none can ever be a real mail
+// host. Names are ipaddr.js range() categories.
+const ALWAYS_INVALID_RANGES = new Set(['unspecified', 'broadcast', 'multicast']);
+
+// Local / private-scope ranges. Rejected only when blockLocalAddresses is enabled, to
+// prevent SSRF and DNS-rebinding via MX records that point at internal hosts. Covers
+// IPv4 loopback (127.0.0.0/8), RFC1918 private, link-local (169.254.0.0/16) and
+// carrier-grade NAT (100.64.0.0/10); IPv6 loopback (::1), unique-local (fc00::/7) and
+// link-local (fe80::/10).
+const LOCAL_RANGES = new Set(['loopback', 'private', 'linkLocal', 'carrierGradeNat', 'uniqueLocal']);
+
+// IANA "reserved" range: future-use 240.0.0.0/4 plus the RFC 5737 / RFC 3849 documentation
+// ranges. Rejected only when blockReservedNetworks is enabled - off by default so those
+// documentation ranges stay usable in tests and staging fixtures.
+const RESERVED_RANGES = new Set(['reserved']);
+
 /**
  * Validates an IP address for use as an MX server destination.
  *
  * Checks against several invalid/problematic ranges:
- * - Always blocked: 'unspecified' (0.0.0.0) and 'broadcast' addresses
- * - Conditionally blocked (when blockLocalAddresses=true): 'loopback', 'private', and local interface IPs
+ * - Always blocked (never valid unicast targets): 'unspecified' (0.0.0.0), 'broadcast'
+ *   and 'multicast'
+ * - Blocked when blockLocalAddresses=true: local/private-scope ranges ('loopback',
+ *   'private', 'linkLocal', 'carrierGradeNat', 'uniqueLocal') and any IP assigned to a
+ *   local interface
+ * - Blocked when blockReservedNetworks=true: 'reserved' (future-use and documentation ranges)
  *
  * This prevents connections to:
  * - Misconfigured domains pointing to invalid addresses
@@ -136,7 +158,8 @@ function isLocal(address) {
  *
  * @param {Object} delivery - The delivery object containing dnsOptions
  * @param {Object} [delivery.dnsOptions] - DNS configuration options
- * @param {boolean} [delivery.dnsOptions.blockLocalAddresses=false] - Block private/loopback IPs
+ * @param {boolean} [delivery.dnsOptions.blockLocalAddresses=false] - Block local/private-scope IPs
+ * @param {boolean} [delivery.dnsOptions.blockReservedNetworks=false] - Block multicast/reserved IPs
  * @param {string} ip - The IP address to validate
  * @returns {string|false} Error message string if invalid, false if valid
  */
@@ -149,9 +172,9 @@ function isInvalid(delivery, ip) {
     }
     const dnsOptions = delivery.dnsOptions || {};
 
-    // Optionally block private networks and loopback (prevents SSRF-like attacks via MX)
+    // Optionally block local/private-scope ranges (prevents SSRF-like attacks via MX)
     if (dnsOptions.blockLocalAddresses) {
-        if (range === 'loopback' || range === 'private') {
+        if (LOCAL_RANGES.has(range)) {
             return `This IP address falls within the prohibited "${range}" address range, which is not valid for external communication.`;
         }
 
@@ -160,8 +183,13 @@ function isInvalid(delivery, ip) {
         }
     }
 
-    // Always block unspecified (0.0.0.0) and broadcast addresses
-    if (range === 'unspecified' || range === 'broadcast') {
+    // Optionally block reserved ranges (future-use, documentation)
+    if (dnsOptions.blockReservedNetworks && RESERVED_RANGES.has(range)) {
+        return `The IP address is within the disallowed "${range}" address range, which is not permitted for direct communication.`;
+    }
+
+    // Always block ranges that are never valid unicast SMTP destinations
+    if (ALWAYS_INVALID_RANGES.has(range)) {
         return `The IP address is within the disallowed "${range}" address range, which is not permitted for direct communication.`;
     }
 

--- a/test/resolve-mx-test.js
+++ b/test/resolve-mx-test.js
@@ -79,6 +79,78 @@ module.exports.blockedLocalAddress = test => {
         });
 };
 
+module.exports.nullMxRejected = test => {
+    const mockResolver = createMockDnsResolver({
+        'nomail.example.com:MX': { data: [{ exchange: '.', priority: 0 }] }
+    });
+
+    resolveMx({
+        domain: 'nomail.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'nomail.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(() => {
+            test.ok(false, 'Should have rejected null MX');
+            test.done();
+        })
+        .catch(err => {
+            test.equal(err.category, 'dns');
+            test.equal(err.code, 'ENULLMX');
+            // Null MX is a permanent refusal - must not be marked temporary
+            test.ok(!err.temporary);
+            test.done();
+        });
+};
+
+module.exports.nullMxEmptyExchangeRejected = test => {
+    // Some resolvers surface the root exchange as an empty string rather than "."
+    const mockResolver = createMockDnsResolver({
+        'nomail2.example.com:MX': { data: [{ exchange: '', priority: 0 }] }
+    });
+
+    resolveMx({
+        domain: 'nomail2.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'nomail2.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(() => {
+            test.ok(false, 'Should have rejected null MX');
+            test.done();
+        })
+        .catch(err => {
+            test.equal(err.code, 'ENULLMX');
+            test.done();
+        });
+};
+
+module.exports.nullMxDoesNotFallBackToA = test => {
+    // Even if an A record exists, a null MX must prevent delivery (no A/AAAA fallback)
+    const mockResolver = createMockDnsResolver({
+        'nomail3.example.com:MX': { data: [{ exchange: '.', priority: 0 }] },
+        'nomail3.example.com:A': { data: ['192.0.2.1'] }
+    });
+
+    resolveMx({
+        domain: 'nomail3.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'nomail3.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(() => {
+            test.ok(false, 'Should have rejected null MX without falling back to A');
+            test.done();
+        })
+        .catch(err => {
+            test.equal(err.code, 'ENULLMX');
+            test.done();
+        });
+};
+
 module.exports.mxRecordsSorted = test => {
     const mockResolver = createMockDnsResolver({
         'multi.example.com:MX': {

--- a/test/tools-test.js
+++ b/test/tools-test.js
@@ -133,5 +133,29 @@ module.exports.isInvalid = test => {
         )
     );
 
+    // multicast is never a valid unicast destination - blocked regardless of options
+    test.ok(tools.isInvalid({ dnsOptions: {} }, '224.0.0.1'));
+    test.ok(tools.isInvalid({ dnsOptions: {} }, 'ff02::1'));
+
+    // reserved (future-use / documentation) is blocked only when blockReservedNetworks=true
+    test.equal(tools.isInvalid({ dnsOptions: {} }, '240.0.0.1'), false);
+    test.ok(tools.isInvalid({ dnsOptions: { blockReservedNetworks: true } }, '240.0.0.1'));
+    // documentation ranges (RFC 5737 / 3849) are 'reserved' too - allowed by default
+    test.equal(tools.isInvalid({ dnsOptions: {} }, '192.0.2.1'), false);
+    test.ok(tools.isInvalid({ dnsOptions: { blockReservedNetworks: true } }, '192.0.2.1'));
+
+    // link-local, CGNAT and IPv6 unique-local are local-scope: only blocked when blockLocalAddresses=true
+    for (const ip of ['169.254.1.1', '100.64.0.1', 'fe80::1', 'fc00::1']) {
+        test.equal(tools.isInvalid({ dnsOptions: {} }, ip), false);
+        test.ok(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, ip));
+    }
+
+    // IPv6 loopback is blocked with blockLocalAddresses, allowed without
+    test.equal(tools.isInvalid({ dnsOptions: {} }, '::1'), false);
+    test.ok(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '::1'));
+
+    // public unicast addresses remain valid in both modes
+    test.equal(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '2606:4700:4700::1111'), false);
+
     test.done();
 };


### PR DESCRIPTION
isInvalid():
- always block multicast (224.0.0.0/4, ff00::/8) alongside unspecified and broadcast - never valid unicast mail destinations
- under blockLocalAddresses, also block IPv4/IPv6 link-local, IPv6 unique-local (fc00::/7) and carrier-grade NAT (100.64.0.0/10)
- add opt-in blockReservedNetworks for IANA "reserved" (future-use 240.0.0.0/4 and the RFC 5737 / RFC 3849 documentation ranges), default off so documentation ranges stay usable in tests/staging

resolve-mx(): detect RFC 7505 null MX ("0 .") and fail permanently (category=dns, code=ENULLMX, non-temporary) instead of trying to connect to the root; do not fall back to A/AAAA. c-ares surfaces the root exchange as "", a custom dnsOptions.resolve may pass ".", both are treated as null MX.

Tests updated for the new ranges, the blockReservedNetworks flag, and null MX (empty-string and literal-dot forms).