### PR TITLE
fix(dns): unwrap IPv4-mapped IPv6 and narrow null MX rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ You can use a domain name or an email address as the target, for additional conf
 - **dnsOptions** is an object for IP address related options
     - **ignoreIPv6** (boolean, defaults to `false`) If true then never use IPv6 addresses for sending
     - **preferIPv6** (boolean, defaults to `false`) If true then use IPv6 address even if IPv4 address is also available
-    - **blockLocalAddresses** (boolean, defaults to `false`) If true then refuses to connect to IP addresses that are either in loopback, private network or attached to the server. People put every kind of stuff in MX records, you do not want to flood your loopback interface because someone thought it is a great idea to set 127.0.0.1 as the MX server
+    - **blockLocalAddresses** (boolean, defaults to `false`) If true then refuses to connect to IP addresses that are in a local or private scope, or attached to the server. People put every kind of stuff in MX records, you do not want to flood your loopback interface because someone thought it is a great idea to set 127.0.0.1 as the MX server. Covers loopback (`127.0.0.0/8`, `::1`), private networks (RFC1918), link-local (`169.254.0.0/16`, `fe80::/10`), carrier-grade NAT (`100.64.0.0/10`) and IPv6 unique-local (`fc00::/7`)
+    - **blockReservedNetworks** (boolean, defaults to `false`) If true then also refuses to connect to IANA reserved addresses: future-use (`240.0.0.0/4`) and the documentation ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32`). Off by default so that the documentation ranges stay usable in tests and staging setups
     - **resolve** (function, defaults to native `dns.resolve`) Custom callback-style DNS resolver function with signature `resolve(domain, type, callback)` or `resolve(domain, callback)`
+
+    Addresses that can never be a real mail host are always rejected, whatever the options above are set to: the unspecified address (`0.0.0.0`, `::`), the limited broadcast address (`255.255.255.255`) and multicast (`224.0.0.0/4`, `ff00::/8`). IPv4-mapped IPv6 addresses (for example `::ffff:127.0.0.1`) are unwrapped and judged as the IPv4 address they actually reach, so they cannot be used to slip past `blockLocalAddresses`.
+
 - **mx** is a hostname string, a resolved MX object, or an array of either, to skip DNS resolving. Useful if you want to connect to a specific host. String entries are treated as hostnames (or IP addresses) with priority 0.
     - **exchange** is the hostname of the MX
     - **priority** (defaults to 0) is the MX priority number that is used to sort available MX servers (servers with higher priority are tried first)
@@ -101,6 +105,12 @@ You can use a domain name or an email address as the target, for additional conf
     - **checkDnssecSecure(hostname)** - optional async function to check DNSSEC validation status of an MX host before attempting TLSA lookups ([RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2)). Should return `{ secure: boolean }`. When provided and the zone is insecure, TLSA lookups are skipped and the connection falls back to opportunistic TLS. See [DNSSEC-Aware DANE](#dnssec-aware-dane) below
     - **logger(logObj)** - method to log DANE information, logging is disabled by default
     - **verify** - if `true` (default), enforces DANE verification and rejects connections that fail. If `false`, only logs failures
+
+### Null MX
+
+If a domain publishes an [RFC 7505](https://datatracker.ietf.org/doc/html/rfc7505) null MX record (`0 .`), it states that it accepts no mail at all. Resolving such a target fails permanently with `err.code = 'ENULLMX'`, and no fallback to A/AAAA records is attempted. Treat it as a permanent rejection, there is no point in retrying it later.
+
+A null MX published alongside real MX records is a misconfiguration, RFC 7505 Section 4.1 forbids the combination. In that case the null entry is ignored and delivery proceeds using the remaining MX records.
 
 ### Connection object
 

--- a/lib/resolve-mx.js
+++ b/lib/resolve-mx.js
@@ -193,14 +193,25 @@ async function resolveMX(delivery) {
     // Step 1: Try MX records (canonical mail server entries)
     const mxResult = await tryResolve(dnsResolve, domain, 'MX');
     if (mxResult.list.length) {
-        // RFC 7505 null MX: a "0 ." record signals the domain accepts no mail. Fail
-        // permanently instead of treating "." as a hostname (which would otherwise fail
-        // as a confusing resolution error) and do NOT fall back to A/AAAA records.
-        if (mxResult.list.some(isNullMx)) {
+        // RFC 7505 null MX: a "0 ." record signals the domain accepts no mail. Drop such
+        // entries so "." is never treated as a hostname (which would otherwise fail as a
+        // confusing resolution error).
+        const usable = mxResult.list.filter(entry => !isNullMx(entry));
+
+        // Only a null MX on its own is an authoritative "no mail here". Fail permanently and
+        // do NOT fall back to A/AAAA records.
+        //
+        // RFC 7505 Section 4.1 forbids publishing a null MX alongside other MX records, so a
+        // mix is a misconfiguration rather than a refusal. Deliver via the remaining records
+        // instead of bouncing a domain that plainly still accepts mail - the same leniency
+        // keeps a single malformed entry (an empty exchange from a custom resolver) from
+        // taking down an otherwise valid MX set.
+        if (!usable.length) {
             throw createNullMxError(domain);
         }
+
         // Sort by priority (lower number = higher priority) per RFC 5321
-        delivery.mx = mxResult.list
+        delivery.mx = usable
             .slice()
             .sort((a, b) => a.priority - b.priority)
             .map(entry => ({ ...entry, mx: true, A: [], AAAA: [] }));

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -156,6 +156,8 @@ const RESERVED_RANGES = new Set(['reserved']);
  * - Potential security issues (DNS rebinding, SSRF via MX records)
  * - Accidental localhost connections that could flood local services
  *
+ * IPv4-mapped IPv6 addresses are unwrapped before validation, see below.
+ *
  * @param {Object} delivery - The delivery object containing dnsOptions
  * @param {Object} [delivery.dnsOptions] - DNS configuration options
  * @param {boolean} [delivery.dnsOptions.blockLocalAddresses=false] - Block local/private-scope IPs
@@ -164,12 +166,22 @@ const RESERVED_RANGES = new Set(['reserved']);
  * @returns {string|false} Error message string if invalid, false if valid
  */
 function isInvalid(delivery, ip) {
-    let range;
+    let addr;
     try {
-        range = ipaddr.parse(ip).range();
+        addr = ipaddr.parse(ip);
     } catch {
         return 'Failed parsing IP address range.';
     }
+
+    // An IPv4-mapped IPv6 address (::ffff:127.0.0.1) reports its own "ipv4Mapped" range, so
+    // it would match none of the IPv4 ranges below while still connecting straight to the
+    // embedded IPv4 host. Unwrap it so it is validated as the IPv4 address it reaches.
+    if (addr.kind() === 'ipv6' && addr.isIPv4MappedAddress()) {
+        addr = addr.toIPv4Address();
+    }
+
+    const range = addr.range();
+    const normalizedIp = addr.toString();
     const dnsOptions = delivery.dnsOptions || {};
 
     // Optionally block local/private-scope ranges (prevents SSRF-like attacks via MX)
@@ -178,7 +190,9 @@ function isInvalid(delivery, ip) {
             return `This IP address falls within the prohibited "${range}" address range, which is not valid for external communication.`;
         }
 
-        if (isLocal(ip)) {
+        // Check both forms: the interface list holds canonical addresses, while the input may
+        // be an alternate notation of the same address (mapped, uppercase, uncompressed).
+        if (isLocal(ip) || isLocal(normalizedIp)) {
             return 'The resolved IP address corresponds to a local interface.';
         }
     }

--- a/test/resolve-mx-test.js
+++ b/test/resolve-mx-test.js
@@ -151,6 +151,94 @@ module.exports.nullMxDoesNotFallBackToA = test => {
         });
 };
 
+module.exports.nullMxAlongsideRealMxIsIgnored = test => {
+    // RFC 7505 Section 4.1 forbids mixing a null MX with real ones, so this is a
+    // misconfiguration, not a refusal. Deliver via the usable records rather than bounce.
+    const mockResolver = createMockDnsResolver({
+        'mixed.example.com:MX': {
+            data: [
+                { exchange: '.', priority: 0 },
+                { exchange: 'mail.example.com', priority: 10 }
+            ]
+        }
+    });
+
+    resolveMx({
+        domain: 'mixed.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'mixed.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(delivery => {
+            test.equal(delivery.mx.length, 1);
+            test.equal(delivery.mx[0].exchange, 'mail.example.com');
+            test.done();
+        })
+        .catch(err => {
+            test.ok(false, `Should not have rejected a misconfigured MX set: ${err.message}`);
+            test.done();
+        });
+};
+
+module.exports.emptyExchangeAlongsideRealMxIsIgnored = test => {
+    // A single malformed entry (empty exchange from a custom resolver) must not take down
+    // an otherwise valid MX set
+    const mockResolver = createMockDnsResolver({
+        'malformed.example.com:MX': {
+            data: [
+                { exchange: '', priority: 5 },
+                { exchange: 'mail.example.com', priority: 10 }
+            ]
+        }
+    });
+
+    resolveMx({
+        domain: 'malformed.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'malformed.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(delivery => {
+            test.equal(delivery.mx.length, 1);
+            test.equal(delivery.mx[0].exchange, 'mail.example.com');
+            test.done();
+        })
+        .catch(err => {
+            test.ok(false, `Should not have rejected a malformed MX set: ${err.message}`);
+            test.done();
+        });
+};
+
+module.exports.allNullMxRejected = test => {
+    // Multiple null MX entries are still an authoritative "no mail here"
+    const mockResolver = createMockDnsResolver({
+        'nomail4.example.com:MX': {
+            data: [
+                { exchange: '.', priority: 0 },
+                { exchange: '', priority: 0 }
+            ]
+        }
+    });
+
+    resolveMx({
+        domain: 'nomail4.example.com',
+        isIp: false,
+        isPunycode: false,
+        decodedDomain: 'nomail4.example.com',
+        dnsOptions: { resolve: mockResolver }
+    })
+        .then(() => {
+            test.ok(false, 'Should have rejected null MX');
+            test.done();
+        })
+        .catch(err => {
+            test.equal(err.code, 'ENULLMX');
+            test.done();
+        });
+};
+
 module.exports.mxRecordsSorted = test => {
     const mockResolver = createMockDnsResolver({
         'multi.example.com:MX': {

--- a/test/tools-test.js
+++ b/test/tools-test.js
@@ -157,5 +157,27 @@ module.exports.isInvalid = test => {
     // public unicast addresses remain valid in both modes
     test.equal(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '2606:4700:4700::1111'), false);
 
+    // IPv4-mapped IPv6 addresses connect to the embedded IPv4 host, so they must be judged as
+    // that IPv4 address rather than slipping through on their own "ipv4Mapped" range
+    for (const ip of ['::ffff:127.0.0.1', '::ffff:10.0.0.1', '::ffff:169.254.169.254', '::ffff:100.64.0.1']) {
+        test.ok(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, ip), `${ip} should be blocked with blockLocalAddresses`);
+    }
+
+    // mapped forms of the always-invalid ranges are blocked with no options set
+    test.ok(tools.isInvalid({ dnsOptions: {} }, '::ffff:0.0.0.0'));
+    test.ok(tools.isInvalid({ dnsOptions: {} }, '::ffff:255.255.255.255'));
+    test.ok(tools.isInvalid({ dnsOptions: {} }, '::ffff:224.0.0.1'));
+
+    // mapped documentation ranges follow blockReservedNetworks like their bare IPv4 form
+    test.equal(tools.isInvalid({ dnsOptions: {} }, '::ffff:192.0.2.1'), false);
+    test.ok(tools.isInvalid({ dnsOptions: { blockReservedNetworks: true } }, '::ffff:192.0.2.1'));
+
+    // a mapped public address is still deliverable - unwrapping must not over-block
+    test.equal(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '::ffff:8.8.8.8'), false);
+
+    // alternate notations of the same mapped address are handled identically
+    test.ok(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '::FFFF:127.0.0.1'));
+    test.ok(tools.isInvalid({ dnsOptions: { blockLocalAddresses: true } }, '0:0:0:0:0:ffff:7f00:1'));
+
     test.done();
 };


### PR DESCRIPTION
Follow-up to #26.

**IPv4-mapped IPv6 bypass.** `isInvalid()` judged mapped addresses on their own `ipv4Mapped` range, which matches none of the IPv4 range checks. `::ffff:127.0.0.1` and `::ffff:169.254.169.254` passed validation even with `blockLocalAddresses` and `blockReservedNetworks` both enabled, while still connecting straight to the embedded IPv4 host, so a single AAAA record was enough to reach loopback or a cloud metadata endpoint. Mapped addresses are now unwrapped before the range check, and local interface addresses are matched against both the original and normalized form.

**Null MX.** Detection used `.some()`, so a null MX mixed with real MX records rejected the whole domain with a permanent `ENULLMX`. RFC 7505 Section 4.1 forbids that combination, making it a misconfiguration rather than a refusal, so the null entry is now ignored and delivery proceeds via the remaining records. This also stops one malformed entry (an empty exchange from a custom resolver, which `isNullMx()` matches) from taking down a valid MX set.

**Docs.** README now covers `blockReservedNetworks`, the widened `blockLocalAddresses` ranges, the always-blocked ranges, and null MX handling.

Both gaps are pre-release, #26 has not shipped yet, so 1.7.0 notes should describe the behavior as it lands here.