### PR TITLE
fix(dane): harden DNS error handling, verify TA chain linkage, drop verify opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can use a domain name or an email address as the target, for additional conf
     - **resolveTlsa(tlsaName)** - custom async function to resolve TLSA records. Receives the full TLSA query name (e.g., `_25._tcp.mail.example.com`). If not provided, uses native `dns.resolveTlsa` when available
     - **checkDnssecSecure(hostname)** - optional async function to check DNSSEC validation status of an MX host before attempting TLSA lookups ([RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2)). Should return `{ secure: boolean }`. When provided and the zone is insecure, TLSA lookups are skipped and the connection falls back to opportunistic TLS. See [DNSSEC-Aware DANE](#dnssec-aware-dane) below
     - **logger(logObj)** - method to log DANE information, logging is disabled by default
-    - **verify** - if `true` (default), enforces DANE verification and rejects connections that fail. If `false`, only logs failures
+    - **verify** - *(deprecated, ignored)* DANE verification is always enforced when TLSA records are present, per RFC 7672. This option is accepted for backward compatibility but has no effect
 
 ### Connection object
 
@@ -215,17 +215,17 @@ const connection = await mxConnect({
 });
 ```
 
-When `checkDnssecSecure` reports that a zone is insecure, mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error, the zone is assumed insecure (safe default). If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
+When `checkDnssecSecure` reports that a zone is insecure (`{ secure: false }`), mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error (e.g. DNS timeout), the MX is marked as having a DANE lookup failure and the connection is rejected with a temporary error, preserving DANE enforcement across retries. If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
 
 ### DANE Verification Flow
 
 When DANE is enabled, the following flow occurs:
 
-1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones skip directly to step 5
+1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones (`{ secure: false }`) skip directly to step 5. If the check itself fails (DNS error), the MX is marked as a DANE lookup failure and the connection is rejected with a temporary error
 2. **TLSA Lookup**: For hosts in DNSSEC-signed zones (or when `checkDnssecSecure` is not provided), mx-connect resolves TLSA records for each MX hostname (e.g., `_25._tcp.mail.example.com`)
 3. **Connection**: A TCP connection is established to the MX server
-4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option
-5. **Certificate Verification**: The server's certificate is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
+4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option. Pass the certificate chain (from `socket.getPeerCertificate(true)`) as the third argument for DANE-TA/PKIX-TA support
+5. **Certificate Verification**: The server's certificate (and chain, if provided) is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
 
 ### TLSA Record Format
 
@@ -245,12 +245,12 @@ TLSA records returned by the resolver should have the following structure:
 
 | Usage | Name    | Description                                             | Support Status |
 | ----- | ------- | ------------------------------------------------------- | -------------- |
-| 0     | PKIX-TA | CA constraint - must chain to specified CA              | ⚠️ Limited\*   |
+| 0     | PKIX-TA | CA constraint - must chain to specified CA              | ✅ Full\*       |
 | 1     | PKIX-EE | Service certificate constraint - must match exactly     | ✅ Full        |
-| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | ⚠️ Limited\*   |
+| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | ✅ Full\*       |
 | 3     | DANE-EE | Domain-issued certificate - certificate must match      | ✅ Full        |
 
-> **\*Note on DANE-TA and PKIX-TA**: These usage types require access to the full certificate chain, which is not available in the standard TLS `checkServerIdentity` callback. Currently, only the end-entity (leaf) certificate is verified. If the TLSA record matches the end-entity certificate, verification will succeed; otherwise, it will fail even if the record matches a CA certificate in the chain. For most SMTP deployments, DANE-EE (usage=3) is recommended as it provides the strongest security guarantees and is fully supported.
+> **\*Note on DANE-TA and PKIX-TA**: These usage types require access to the full certificate chain. The `createDaneVerifier` function returned by this module accepts an optional `chain` parameter (an array of `X509Certificate` objects) that enables DANE-TA and PKIX-TA verification against CA certificates in the chain. When the chain is not provided, only the end-entity (leaf) certificate is verified and DANE-TA/PKIX-TA records will fail to match. For most SMTP deployments, DANE-EE (usage=3) is recommended as it provides the strongest security guarantees.
 
 ### Combining DANE with MTA-STS
 
@@ -287,8 +287,8 @@ console.log('DANE Usage Types:', dane.DANE_USAGE);
 console.log('DANE Selectors:', dane.DANE_SELECTOR);
 console.log('DANE Matching Types:', dane.DANE_MATCHING_TYPE);
 
-// Verify a certificate against TLSA records
-const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords);
+// Verify a certificate against TLSA records (with optional chain for DANE-TA)
+const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords, chain);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can use a domain name or an email address as the target, for additional conf
     - **resolveTlsa(tlsaName)** - custom async function to resolve TLSA records. Receives the full TLSA query name (e.g., `_25._tcp.mail.example.com`). If not provided, uses native `dns.resolveTlsa` when available
     - **checkDnssecSecure(hostname)** - optional async function to check DNSSEC validation status of an MX host before attempting TLSA lookups ([RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2)). Should return `{ secure: boolean }`. When provided and the zone is insecure, TLSA lookups are skipped and the connection falls back to opportunistic TLS. See [DNSSEC-Aware DANE](#dnssec-aware-dane) below
     - **logger(logObj)** - method to log DANE information, logging is disabled by default
-    - **verify** - if `true` (default), enforces DANE verification and rejects connections that fail. If `false`, only logs failures
+    - **verify** - _(deprecated, ignored)_ DANE verification is always enforced when TLSA records are present, per RFC 7672. This option is accepted for backward compatibility but has no effect
 
 ### Null MX
 
@@ -225,17 +225,40 @@ const connection = await mxConnect({
 });
 ```
 
-When `checkDnssecSecure` reports that a zone is insecure, mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error, the zone is assumed insecure (safe default). If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
+When `checkDnssecSecure` reports that a zone is insecure (`{ secure: false }`), mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error (e.g. DNS timeout), the MX is marked as having a DANE lookup failure and the connection is rejected with a temporary error, preserving DANE enforcement across retries. If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
 
 ### DANE Verification Flow
 
 When DANE is enabled, the following flow occurs:
 
-1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones skip directly to step 5
+1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones (`{ secure: false }`) skip directly to step 5. If the check itself fails (DNS error), the MX is marked as a DANE lookup failure and the connection is rejected with a temporary error
 2. **TLSA Lookup**: For hosts in DNSSEC-signed zones (or when `checkDnssecSecure` is not provided), mx-connect resolves TLSA records for each MX hostname (e.g., `_25._tcp.mail.example.com`)
 3. **Connection**: A TCP connection is established to the MX server
 4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option
 5. **Certificate Verification**: The server's certificate is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
+
+`connection.daneVerifier` has the signature `(hostname, cert, chain)`. Node only ever calls `checkServerIdentity` with `(hostname, cert)`, so the leaf certificate alone is checked when it is wired up as shown above - enough for DANE-EE (usage 3) and PKIX-EE (usage 1). To also cover DANE-TA (usage 2) and PKIX-TA (usage 0), call the verifier yourself after the handshake and pass the issuer chain as an **array of `X509Certificate` objects**:
+
+```javascript
+const leaf = socket.getPeerX509Certificate();
+
+// the chain holds the issuers only, the leaf is passed separately
+const chain = [];
+for (let cert = leaf && leaf.issuerCertificate; cert; cert = cert.issuerCertificate) {
+    chain.push(cert);
+}
+
+const err = connection.daneVerifier(hostname, leaf, chain);
+if (err) {
+    socket.destroy();
+    throw err;
+}
+```
+
+Two caveats when relying on DANE:
+
+- Node only invokes `checkServerIdentity` after its own PKIX validation has passed, so with the default `rejectUnauthorized: true` a certificate that fails PKIX is rejected before the DANE verifier ever runs. DANE-EE certificates are frequently self-signed, which is exactly the case PKIX rejects. Set `rejectUnauthorized: false` and treat the verifier's result as the authority.
+- Because of the above, when TLSA records are present the verifier's return value is the only thing standing between you and an intercepted connection. Always destroy the socket when it returns an error, as shown.
 
 ### TLSA Record Format
 
@@ -255,12 +278,16 @@ TLSA records returned by the resolver should have the following structure:
 
 | Usage | Name    | Description                                             | Support Status |
 | ----- | ------- | ------------------------------------------------------- | -------------- |
-| 0     | PKIX-TA | CA constraint - must chain to specified CA              | ⚠️ Limited\*   |
-| 1     | PKIX-EE | Service certificate constraint - must match exactly     | ✅ Full        |
-| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | ⚠️ Limited\*   |
-| 3     | DANE-EE | Domain-issued certificate - certificate must match      | ✅ Full        |
+| 0     | PKIX-TA | CA constraint - must chain to specified CA              | Partial\*      |
+| 1     | PKIX-EE | Service certificate constraint - must match exactly     | Full           |
+| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | Full\*         |
+| 3     | DANE-EE | Domain-issued certificate - certificate must match      | Full           |
 
-> **\*Note on DANE-TA and PKIX-TA**: These usage types require access to the full certificate chain, which is not available in the standard TLS `checkServerIdentity` callback. Currently, only the end-entity (leaf) certificate is verified. If the TLSA record matches the end-entity certificate, verification will succeed; otherwise, it will fail even if the record matches a CA certificate in the chain. For most SMTP deployments, DANE-EE (usage=3) is recommended as it provides the strongest security guarantees and is fully supported.
+> **\*Note on DANE-TA and PKIX-TA**: These usage types need the issuer chain, which Node does not pass to a `checkServerIdentity` callback. `createDaneVerifier` accepts an optional `chain` argument (an array of `X509Certificate` objects) to supply it - see [DANE Verification Flow](#dane-verification-flow). Without a chain, only the end-entity certificate is checked and DANE-TA/PKIX-TA records never match.
+>
+> The pinned certificate must lie on a signature-verified path from the certificate the server presented. A certificate that merely appears in the chain is not accepted: the trust anchor a TLSA record pins is public, so otherwise anyone could present their own certificate with the pinned CA stapled onto the chain.
+>
+> PKIX-TA (usage 0) remains partial: it does not additionally require PKIX path validation to have succeeded ([RFC 7671 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7671#section-5.1)). [RFC 7672 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7672#section-3.1) makes usages 0 and 1 inapplicable to SMTP in any case - for SMTP, prefer DANE-EE (usage 3).
 
 ### Combining DANE with MTA-STS
 
@@ -297,8 +324,8 @@ console.log('DANE Usage Types:', dane.DANE_USAGE);
 console.log('DANE Selectors:', dane.DANE_SELECTOR);
 console.log('DANE Matching Types:', dane.DANE_MATCHING_TYPE);
 
-// Verify a certificate against TLSA records
-const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords);
+// Verify a certificate against TLSA records (with optional chain for DANE-TA)
+const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords, chain);
 ```
 
 ## License

--- a/lib/dane.js
+++ b/lib/dane.js
@@ -362,23 +362,29 @@ function daneError(message, code) {
  * Create a TLS verification function for DANE
  * @param {Array} tlsaRecords - Array of TLSA records
  * @param {Object} options - DANE options
- * @returns {Function} TLS checkServerIdentity function
+ * @returns {Function} checkServerIdentity(hostname, cert, chain) - Returns undefined on
+ *   success or an Error on failure. The optional `chain` parameter is an array of
+ *   X509Certificate objects representing the issuer chain, required for DANE-TA (usage 2)
+ *   and PKIX-TA (usage 0) verification.
  */
 function createDaneVerifier(tlsaRecords, options) {
-    return function checkServerIdentity(hostname, cert) {
+    return function checkServerIdentity(hostname, cert, chain) {
         if (!tlsaRecords || tlsaRecords.length === 0) {
             return undefined;
         }
 
         try {
-            const result = verifyCertAgainstTlsa(cert, tlsaRecords);
+            const result = verifyCertAgainstTlsa(cert, tlsaRecords, chain);
 
             if (!result.valid && !result.noRecords) {
                 logDane(options, { msg: 'DANE verification failed', success: false, hostname, error: result.error });
-
-                if (options.verify !== false) {
-                    return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
-                }
+                //
+                // RFC 7672 Section 2.2: DANE verification failures MUST be
+                // treated as fatal when usable TLSA records are present.
+                // There is no opt-out — once DANE is enabled the verifier
+                // always returns an error on mismatch.
+                //
+                return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
             }
 
             if (result.valid && result.matchedRecord) {
@@ -399,11 +405,7 @@ function createDaneVerifier(tlsaRecords, options) {
         } catch (err) {
             logDane(options, { msg: 'DANE verification error', success: false, hostname, error: err.message });
 
-            if (options.verify !== false) {
-                return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
-            }
-
-            return undefined;
+            return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
         }
     };
 }

--- a/lib/dane.js
+++ b/lib/dane.js
@@ -20,10 +20,17 @@ const resolveTlsaAsync = hasNativeResolveTlsa ? util.promisify(dns.resolveTlsa) 
  * 3 - DANE-EE: Domain-issued certificate
  *
  * Note: DANE-EE (usage=3) is fully supported. PKIX-EE (usage=1) performs TLSA matching
- * but does not perform additional PKIX path validation. DANE-TA (usage=2) and PKIX-TA
- * (usage=0) require the full certificate chain which is not available in the standard
- * TLS checkServerIdentity callback - these will only work if the chain is explicitly
- * provided or if the matching certificate is the end-entity certificate itself.
+ * but does not perform additional PKIX path validation.
+ *
+ * DANE-TA (usage=2) and PKIX-TA (usage=0) need the issuer chain, which Node does not
+ * pass to a checkServerIdentity callback - the caller must hand it to the verifier
+ * explicitly. When it is supplied, the pinned certificate must lie on a signature
+ * verified path from the end-entity certificate; a certificate that merely appears
+ * in the chain is not accepted (see buildVerifiedPath).
+ *
+ * Remaining gap: usage=0 does not additionally require PKIX path validation to have
+ * succeeded (RFC 7671 Section 5.1). RFC 7672 Section 3.1 makes usages 0 and 1
+ * inapplicable to SMTP in any case; prefer DANE-EE (usage=3).
  */
 const DANE_USAGE = {
     PKIX_TA: 0,
@@ -264,6 +271,98 @@ function matchCert(certToCheck, selector, matchingType, expectedData) {
 }
 
 /**
+ * Coerce a certificate-like value into an X509Certificate.
+ *
+ * Accepts both X509Certificate instances and the raw peer certificate objects
+ * returned by tls.getPeerCertificate(), which carry the DER in `.raw`.
+ *
+ * @param {Object} cert - Certificate to coerce
+ * @returns {nodeCrypto.X509Certificate|null} The certificate, or null if it cannot be parsed
+ * @private
+ */
+function toX509(cert) {
+    if (!cert) {
+        return null;
+    }
+
+    if (cert instanceof nodeCrypto.X509Certificate) {
+        return cert;
+    }
+
+    try {
+        const raw = toBuffer(cert.raw);
+        return raw ? new nodeCrypto.X509Certificate(raw) : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Build the certificate path running from the end-entity certificate up through
+ * the supplied issuer chain, verifying the issuer signature at every hop.
+ *
+ * This is what makes a DANE-TA/PKIX-TA match meaningful. Without it, "the TLSA
+ * record matches some certificate the peer sent" is not a statement about the
+ * certificate the peer is actually presenting: an attacker can append the
+ * pinned trust anchor (a public value, readable from the real server) to a
+ * chain for their own unrelated certificate and be trusted. Only certificates
+ * that genuinely issued the leaf, transitively, may be considered.
+ *
+ * Returns null if the path cannot be established, so callers fail closed.
+ *
+ * @param {Object} cert - The end-entity certificate presented by the server
+ * @param {Array} chain - Issuer certificates supplied by the caller
+ * @returns {Array<nodeCrypto.X509Certificate>|null} Certificates on the verified path, leaf first
+ * @private
+ */
+function buildVerifiedPath(cert, chain) {
+    const leaf = toX509(cert);
+    if (!leaf) {
+        return null;
+    }
+
+    const issuers = [];
+    for (const entry of chain) {
+        const x509 = toX509(entry);
+        if (!x509) {
+            // An entry we cannot parse might be the link we need, so refuse to
+            // reason about this chain at all rather than skipping past it.
+            return null;
+        }
+        issuers.push(x509);
+    }
+
+    const path = [leaf];
+    const used = new Set();
+    let current = leaf;
+
+    // Each hop consumes one issuer, so this terminates even if the peer sends
+    // a chain containing cycles or repeated certificates.
+    for (;;) {
+        const next = issuers.findIndex((candidate, index) => {
+            if (used.has(index)) {
+                return false;
+            }
+            try {
+                return current.checkIssued(candidate) && current.verify(candidate.publicKey);
+            } catch {
+                return false;
+            }
+        });
+
+        if (next === -1) {
+            break;
+        }
+
+        used.add(next);
+        current = issuers[next];
+        path.push(current);
+    }
+
+    return path;
+}
+
+/**
  * Verify a certificate against TLSA records
  * @param {Object} cert - The server certificate (X509Certificate or peer certificate)
  * @param {Array} tlsaRecords - Array of TLSA records
@@ -281,6 +380,10 @@ function verifyCertAgainstTlsa(cert, tlsaRecords, chain) {
 
     const errors = [];
     const hasChain = chain && chain.length > 0;
+
+    // Built lazily on the first trust-anchor record and reused across records.
+    // undefined = not yet attempted, null = no verifiable path exists.
+    let verifiedPath;
 
     for (const record of tlsaRecords) {
         try {
@@ -307,14 +410,28 @@ function verifyCertAgainstTlsa(cert, tlsaRecords, chain) {
                 }
             }
 
-            // For DANE-TA (usage 2) and PKIX-TA (usage 0), verify against the trust anchor in the chain
+            // For DANE-TA (usage 2) and PKIX-TA (usage 0), the record pins a trust
+            // anchor, so the match must be against a certificate that actually
+            // issued the presented leaf - not merely one the peer sent along.
             if (isTA) {
                 if (!hasChain) {
                     errors.push(`TLSA record with usage ${usage} (${USAGE_LABELS[usage]}) requires certificate chain which is not available`);
                     continue;
                 }
-                for (const chainCert of chain) {
-                    const result = matchCert(chainCert, selector, matchingType, expectedData);
+
+                if (verifiedPath === undefined) {
+                    verifiedPath = buildVerifiedPath(cert, chain);
+                }
+
+                if (!verifiedPath) {
+                    errors.push(
+                        `TLSA record with usage ${usage} (${USAGE_LABELS[usage]}) could not be checked: no verified path from the server certificate through the supplied chain`
+                    );
+                    continue;
+                }
+
+                for (const pathCert of verifiedPath) {
+                    const result = matchCert(pathCert, selector, matchingType, expectedData);
                     if (result.matched) {
                         return { valid: true, matchedRecord: record, error: null, usage: USAGE_LABELS[usage] };
                     }
@@ -362,27 +479,35 @@ function daneError(message, code) {
  * Create a TLS verification function for DANE
  * @param {Array} tlsaRecords - Array of TLSA records
  * @param {Object} options - DANE options
- * @returns {Function} TLS checkServerIdentity function
+ * @returns {Function} checkServerIdentity(hostname, cert, chain) - Returns undefined on
+ *   success or an Error on failure. The optional `chain` parameter is an array of
+ *   X509Certificate objects representing the issuer chain, required for DANE-TA (usage 2)
+ *   and PKIX-TA (usage 0) verification.
  */
 function createDaneVerifier(tlsaRecords, options) {
-    return function checkServerIdentity(hostname, cert) {
+    // Capture only the logger: the returned function is retained for the whole
+    // connection, and holding the full options object would keep the caller's
+    // resolveTlsa/checkDnssecSecure callbacks (and whatever they close over)
+    // alive alongside it.
+    const logOptions = { logger: (options && options.logger) || null };
+
+    return function checkServerIdentity(hostname, cert, chain) {
         if (!tlsaRecords || tlsaRecords.length === 0) {
             return undefined;
         }
 
         try {
-            const result = verifyCertAgainstTlsa(cert, tlsaRecords);
+            const result = verifyCertAgainstTlsa(cert, tlsaRecords, chain);
 
             if (!result.valid && !result.noRecords) {
-                logDane(options, { msg: 'DANE verification failed', success: false, hostname, error: result.error });
+                logDane(logOptions, { msg: 'DANE verification failed', success: false, hostname, error: result.error });
 
-                if (options.verify !== false) {
-                    return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
-                }
+                // RFC 7672 Section 2.2: fatal whenever usable TLSA records are present, no opt-out
+                return daneError(`DANE verification failed for ${hostname}: ${result.error}`, 'DANE_VERIFICATION_FAILED');
             }
 
             if (result.valid && result.matchedRecord) {
-                logDane(options, {
+                logDane(logOptions, {
                     msg: 'DANE verification succeeded',
                     success: true,
                     hostname,
@@ -397,13 +522,9 @@ function createDaneVerifier(tlsaRecords, options) {
 
             return undefined;
         } catch (err) {
-            logDane(options, { msg: 'DANE verification error', success: false, hostname, error: err.message });
+            logDane(logOptions, { msg: 'DANE verification error', success: false, hostname, error: err.message });
 
-            if (options.verify !== false) {
-                return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
-            }
-
-            return undefined;
+            return daneError(`DANE verification error for ${hostname}: ${err.message}`, 'DANE_VERIFICATION_ERROR');
         }
     };
 }

--- a/lib/get-connection.js
+++ b/lib/get-connection.js
@@ -305,8 +305,8 @@ function tryConnect(delivery, mx) {
         return Promise.resolve(policyFailure);
     }
 
-    // Check for DANE lookup failures in verify mode
-    if (delivery.dane && delivery.dane.enabled && mx.daneLookupFailed && delivery.dane.verify !== false) {
+    // Check for DANE lookup failures (DNSSEC check or TLSA resolution failed)
+    if (delivery.dane && delivery.dane.enabled && mx.daneLookupFailed) {
         const errMsg = (mx.daneLookupError && mx.daneLookupError.message) || 'unknown error';
         const error = new Error(`DANE TLSA lookup failed for ${mx.hostname}: ${errMsg}`);
         error.response = `DANE error: ${error.message}`;

--- a/lib/mx-connect.js
+++ b/lib/mx-connect.js
@@ -113,6 +113,7 @@ async function validateMxPolicy(delivery) {
  * @param {string} hostname - The MX hostname to check
  * @param {Function|null} logger - Optional DANE logger
  * @returns {Promise<boolean>} True if the zone is DNSSEC-signed
+ * @throws {Error} If the DNSSEC check itself fails (DNS timeout, SERVFAIL, etc.)
  * @private
  */
 async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
@@ -120,12 +121,20 @@ async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
         const result = await checkDnssecSecure(hostname);
         return Boolean(result && result.secure);
     } catch (err) {
-        // If the DNSSEC check itself fails, log it and assume insecure.
-        // This is the safe default: skipping TLSA lookups for a zone we
-        // cannot confirm is signed avoids SERVFAIL-induced delivery failures.
+        //
+        // RFC 7672 Section 2.2: A DNS lookup failure (timeout, SERVFAIL)
+        // is NOT the same as an "insecure" response.  Returning false here
+        // would silently skip the TLSA lookup and bypass DANE entirely on
+        // transient DNS errors (e.g. DoH rate-limit on a queue retry).
+        //
+        // Instead, re-throw so that `resolveDaneTlsa` can mark the MX as
+        // having a DANE lookup failure (`mx.daneLookupFailed = true`).
+        // The connection layer will then reject with a temporary error,
+        // preserving DANE enforcement across retries.
+        //
         if (logger) {
             logger({
-                msg: 'DNSSEC status check failed, assuming insecure',
+                msg: 'DNSSEC status check failed, treating as lookup failure',
                 action: 'dane',
                 success: false,
                 hostname,
@@ -133,7 +142,7 @@ async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
                 code: err.code
             });
         }
-        return false;
+        throw err;
     }
 }
 
@@ -177,29 +186,36 @@ async function resolveDaneTlsa(delivery) {
         //  the first query response is 'insecure' [...], the SMTP client
         //  SHOULD NOT proceed to search for any associated TLSA records."
         //
-        if (typeof delivery.dane.checkDnssecSecure === 'function') {
-            const secure = await isZoneDnssecSecure(
-                delivery.dane.checkDnssecSecure,
-                mx.exchange,
-                delivery.dane.logger
-            );
-
-            if (!secure) {
-                mx.tlsaRecords = [];
-                if (delivery.dane.logger) {
-                    delivery.dane.logger({
-                        msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
-                        action: 'dane',
-                        success: true,
-                        hostname: mx.exchange,
-                        domain: delivery.domain
-                    });
-                }
-                return;
-            }
-        }
-
+        //
+        // DNSSEC check and TLSA resolution are wrapped in a single
+        // try/catch so that transient DNS failures in either step
+        // are handled uniformly: the MX is marked as having a DANE
+        // lookup failure and the connection layer rejects with a
+        // temporary error (preserving DANE enforcement on retries).
+        //
         try {
+            if (typeof delivery.dane.checkDnssecSecure === 'function') {
+                const secure = await isZoneDnssecSecure(
+                    delivery.dane.checkDnssecSecure,
+                    mx.exchange,
+                    delivery.dane.logger
+                );
+
+                if (!secure) {
+                    mx.tlsaRecords = [];
+                    if (delivery.dane.logger) {
+                        delivery.dane.logger({
+                            msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
+                            action: 'dane',
+                            success: true,
+                            hostname: mx.exchange,
+                            domain: delivery.domain
+                        });
+                    }
+                    return;
+                }
+            }
+
             mx.tlsaRecords = await dane.resolveTlsaRecords(mx.exchange, port, delivery.dane);
 
             if (mx.tlsaRecords.length > 0 && delivery.dane.logger) {
@@ -213,14 +229,14 @@ async function resolveDaneTlsa(delivery) {
                 });
             }
         } catch (err) {
-            // DNS errors (SERVFAIL, timeout) should not silently bypass DANE
-            // when verify mode is enabled. NODATA/NXDOMAIN are acceptable (no DANE records).
+            // DNS errors (SERVFAIL, timeout) should not silently bypass DANE.
+            // NODATA/NXDOMAIN are acceptable (no DANE records).
             mx.tlsaRecords = [];
             const isNoRecords = dane.isNoRecordsError(err.code);
 
             if (delivery.dane.logger) {
                 delivery.dane.logger({
-                    msg: 'TLSA lookup failed',
+                    msg: 'DANE DNS lookup failed',
                     action: 'dane',
                     success: false,
                     hostname: mx.exchange,
@@ -231,9 +247,10 @@ async function resolveDaneTlsa(delivery) {
                 });
             }
 
-            // If verify is enabled and this is a real DNS failure (not just "no records"),
-            // mark the MX as having a DANE lookup failure so connection can handle it
-            if (delivery.dane.verify !== false && !isNoRecords) {
+            // If this is a real DNS failure (not just "no records"),
+            // mark the MX as having a DANE lookup failure so connection can handle it.
+            // This covers both DNSSEC check failures and TLSA resolution failures.
+            if (!isNoRecords) {
                 mx.daneLookupFailed = true;
                 mx.daneLookupError = err;
             }
@@ -352,7 +369,9 @@ function buildDeliveryObject(options) {
         // Signature: async (hostname) => { secure: boolean }
         checkDnssecSecure: daneOptions.checkDnssecSecure || null,
         logger: daneOptions.logger || null,
-        verify: daneOptions.verify !== undefined ? daneOptions.verify : true
+        // NOTE: verify is always true — DANE enforcement is mandatory per RFC 7672.
+        // The option is accepted for backward compatibility but has no effect.
+        verify: true
     };
 
     return {
@@ -483,7 +502,7 @@ function buildPipeline(delivery) {
  *   DNSSEC status of MX host. Signature: async (hostname) => { secure: boolean }.
  *   When provided and the zone is insecure, TLSA lookups are skipped.
  * @param {Function} [options.dane.logger] - DANE event logger
- * @param {boolean} [options.dane.verify=true] - Enforce DANE verification (reject on failure)
+ * @param {boolean} [options.dane.verify=true] - Deprecated, ignored. DANE verification is always enforced per RFC 7672
  * @param {Function} [callback] - Node.js-style callback: (err, connection)
  * @returns {Promise<Object>} Connection result with socket and metadata
  * @returns {net.Socket} returns.socket - Connected TCP socket

--- a/lib/mx-connect.js
+++ b/lib/mx-connect.js
@@ -98,42 +98,142 @@ async function validateMxPolicy(delivery) {
     return delivery;
 }
 
+const VERIFY_DEPRECATION_MSG = 'The dane.verify option is deprecated and ignored - DANE verification is always enforced per RFC 7672';
+
+let verifyDeprecationWarned = false;
+
 /**
- * Check if the MX host's A/AAAA zone is DNSSEC-signed ("secure").
+ * Warn once per process that `dane.verify: false` no longer disables enforcement.
  *
- * RFC 7672 Section 2.2.2 requires that SMTP clients check the DNSSEC
- * validation status of A/AAAA records before attempting TLSA lookups.
- * If the zone is "insecure" (not DNSSEC-signed), TLSA lookups SHOULD
- * be skipped because:
- *   1. Secure TLSA records cannot exist in an unsigned zone.
- *   2. Some nameservers for unsigned zones return SERVFAIL for TLSA
- *      queries, which would cause delivery failures.
+ * Emitted through process.emitWarning as well as the DANE logger: callers who
+ * never wired a logger are exactly the ones most likely to still be passing
+ * `verify: false`, and they are the ones whose deliveries now start failing.
  *
- * @param {Function} checkDnssecSecure - Async function: (hostname) => { secure: boolean }
- * @param {string} hostname - The MX hostname to check
  * @param {Function|null} logger - Optional DANE logger
- * @returns {Promise<boolean>} True if the zone is DNSSEC-signed
  * @private
  */
-async function isZoneDnssecSecure(checkDnssecSecure, hostname, logger) {
-    try {
-        const result = await checkDnssecSecure(hostname);
-        return Boolean(result && result.secure);
-    } catch (err) {
-        // If the DNSSEC check itself fails, log it and assume insecure.
-        // This is the safe default: skipping TLSA lookups for a zone we
-        // cannot confirm is signed avoids SERVFAIL-induced delivery failures.
-        if (logger) {
-            logger({
-                msg: 'DNSSEC status check failed, assuming insecure',
-                action: 'dane',
-                success: false,
-                hostname,
-                error: err.message,
-                code: err.code
-            });
+function warnVerifyDeprecated(logger) {
+    if (verifyDeprecationWarned) {
+        return;
+    }
+    verifyDeprecationWarned = true;
+
+    process.emitWarning(VERIFY_DEPRECATION_MSG, 'DeprecationWarning', 'MXC_DANE_VERIFY_DEPRECATED');
+
+    if (logger) {
+        logger({
+            msg: VERIFY_DEPRECATION_MSG,
+            action: 'dane',
+            success: false
+        });
+    }
+}
+
+/**
+ * Mark an MX host as unusable for DANE because a lookup it depends on failed.
+ *
+ * A failed lookup is not the same as "this host has no TLSA records" - the
+ * DANE status is simply unknown, so the safe move is to fail closed. The
+ * connection layer turns this into a temporary error, which keeps DANE
+ * enforced when the message is retried instead of quietly downgrading to
+ * opportunistic TLS.
+ *
+ * @param {Object} delivery - The delivery object
+ * @param {Object} mx - The MX entry to mark
+ * @param {Error} err - The lookup error
+ * @param {string} msg - Log message describing which lookup failed
+ * @private
+ */
+function markDaneLookupFailure(delivery, mx, err, msg) {
+    mx.tlsaRecords = [];
+    mx.daneLookupFailed = true;
+    mx.daneLookupError = err;
+
+    if (delivery.dane.logger) {
+        delivery.dane.logger({
+            msg,
+            action: 'dane',
+            success: false,
+            hostname: mx.exchange,
+            domain: delivery.domain,
+            error: err.message,
+            code: err.code
+        });
+    }
+}
+
+/**
+ * Resolve TLSA records for a single MX host.
+ *
+ * @param {Object} delivery - The delivery object
+ * @param {Object} mx - The MX entry to resolve records for
+ * @param {number} port - The port TLSA records are published under
+ * @returns {Promise<void>} Resolves once mx.tlsaRecords has been populated
+ * @private
+ */
+async function resolveTlsaForMx(delivery, mx, port) {
+    // Skip if TLSA records are already provided
+    if (mx.tlsaRecords && mx.tlsaRecords.length > 0) {
+        return;
+    }
+
+    //
+    // RFC 7672 Section 2.2.2: Check DNSSEC status before TLSA lookup
+    //
+    // "the SMTP client MUST perform any A and/or AAAA queries for the
+    //  destination before attempting to locate the associated TLSA records."
+    //
+    // "If address records are found but the DNSSEC validation status of
+    //  the first query response is 'insecure' [...], the SMTP client
+    //  SHOULD NOT proceed to search for any associated TLSA records."
+    //
+    if (typeof delivery.dane.checkDnssecSecure === 'function') {
+        let secure;
+
+        try {
+            const result = await delivery.dane.checkDnssecSecure(mx.exchange);
+            secure = Boolean(result && result.secure);
+        } catch (err) {
+            // A failed check leaves the zone status unknown, which is NOT an
+            // "insecure" answer. Treating it as one would skip the TLSA lookup
+            // and bypass DANE on any transient DNS error - a rate-limited
+            // resolver on a queue retry was enough to downgrade the delivery.
+            return markDaneLookupFailure(delivery, mx, err, 'DNSSEC status check failed');
         }
-        return false;
+
+        if (!secure) {
+            mx.tlsaRecords = [];
+            if (delivery.dane.logger) {
+                delivery.dane.logger({
+                    msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
+                    action: 'dane',
+                    success: true,
+                    hostname: mx.exchange,
+                    domain: delivery.domain
+                });
+            }
+            return;
+        }
+    }
+
+    try {
+        mx.tlsaRecords = await dane.resolveTlsaRecords(mx.exchange, port, delivery.dane);
+    } catch (err) {
+        // NODATA/NXDOMAIN are resolved inside dane.resolveTlsaRecords and come
+        // back as an empty array, so anything thrown here is a real lookup
+        // failure rather than an absence of records.
+        return markDaneLookupFailure(delivery, mx, err, 'TLSA lookup failed');
+    }
+
+    if (mx.tlsaRecords.length > 0 && delivery.dane.logger) {
+        delivery.dane.logger({
+            msg: 'TLSA records found',
+            action: 'dane',
+            success: true,
+            hostname: mx.exchange,
+            domain: delivery.domain,
+            recordCount: mx.tlsaRecords.length
+        });
     }
 }
 
@@ -161,82 +261,7 @@ async function resolveDaneTlsa(delivery) {
     const port = delivery.port || 25;
 
     // Resolve TLSA records for each MX host in parallel
-    const tlsaPromises = delivery.mx.map(async mx => {
-        // Skip if TLSA records are already provided
-        if (mx.tlsaRecords && mx.tlsaRecords.length > 0) {
-            return;
-        }
-
-        //
-        // RFC 7672 Section 2.2.2: Check DNSSEC status before TLSA lookup
-        //
-        // "the SMTP client MUST perform any A and/or AAAA queries for the
-        //  destination before attempting to locate the associated TLSA records."
-        //
-        // "If address records are found but the DNSSEC validation status of
-        //  the first query response is 'insecure' [...], the SMTP client
-        //  SHOULD NOT proceed to search for any associated TLSA records."
-        //
-        if (typeof delivery.dane.checkDnssecSecure === 'function') {
-            const secure = await isZoneDnssecSecure(delivery.dane.checkDnssecSecure, mx.exchange, delivery.dane.logger);
-
-            if (!secure) {
-                mx.tlsaRecords = [];
-                if (delivery.dane.logger) {
-                    delivery.dane.logger({
-                        msg: 'Skipping TLSA lookup for insecure (non-DNSSEC) MX host per RFC 7672 Section 2.2.2',
-                        action: 'dane',
-                        success: true,
-                        hostname: mx.exchange,
-                        domain: delivery.domain
-                    });
-                }
-                return;
-            }
-        }
-
-        try {
-            mx.tlsaRecords = await dane.resolveTlsaRecords(mx.exchange, port, delivery.dane);
-
-            if (mx.tlsaRecords.length > 0 && delivery.dane.logger) {
-                delivery.dane.logger({
-                    msg: 'TLSA records found',
-                    action: 'dane',
-                    success: true,
-                    hostname: mx.exchange,
-                    domain: delivery.domain,
-                    recordCount: mx.tlsaRecords.length
-                });
-            }
-        } catch (err) {
-            // DNS errors (SERVFAIL, timeout) should not silently bypass DANE
-            // when verify mode is enabled. NODATA/NXDOMAIN are acceptable (no DANE records).
-            mx.tlsaRecords = [];
-            const isNoRecords = dane.isNoRecordsError(err.code);
-
-            if (delivery.dane.logger) {
-                delivery.dane.logger({
-                    msg: 'TLSA lookup failed',
-                    action: 'dane',
-                    success: false,
-                    hostname: mx.exchange,
-                    domain: delivery.domain,
-                    error: err.message,
-                    code: err.code,
-                    isNoRecords
-                });
-            }
-
-            // If verify is enabled and this is a real DNS failure (not just "no records"),
-            // mark the MX as having a DANE lookup failure so connection can handle it
-            if (delivery.dane.verify !== false && !isNoRecords) {
-                mx.daneLookupFailed = true;
-                mx.daneLookupError = err;
-            }
-        }
-    });
-
-    await Promise.all(tlsaPromises);
+    await Promise.all(delivery.mx.map(mx => resolveTlsaForMx(delivery, mx, port)));
 
     return delivery;
 }
@@ -347,9 +372,14 @@ function buildDeliveryObject(options) {
         // of MX host A/AAAA records before attempting TLSA lookups.
         // Signature: async (hostname) => { secure: boolean }
         checkDnssecSecure: daneOptions.checkDnssecSecure || null,
-        logger: daneOptions.logger || null,
-        verify: daneOptions.verify !== undefined ? daneOptions.verify : true
+        logger: daneOptions.logger || null
     };
+
+    // `verify` used to allow log-only DANE, which RFC 7672 Section 2.2 does not
+    // permit. Warn rather than change enforcement under the caller silently.
+    if (daneEnabled && daneOptions.verify === false) {
+        warnVerifyDeprecated(daneConfig.logger);
+    }
 
     return {
         // Target domain (extracted from email if needed)
@@ -479,7 +509,8 @@ function buildPipeline(delivery) {
  *   DNSSEC status of MX host. Signature: async (hostname) => { secure: boolean }.
  *   When provided and the zone is insecure, TLSA lookups are skipped.
  * @param {Function} [options.dane.logger] - DANE event logger
- * @param {boolean} [options.dane.verify=true] - Enforce DANE verification (reject on failure)
+ * @param {boolean} [options.dane.verify] - Deprecated and ignored. DANE verification is always enforced
+ *   per RFC 7672; passing `false` logs a deprecation notice through `options.dane.logger`
  * @param {Function} [callback] - Node.js-style callback: (err, connection)
  * @returns {Promise<Object>} Connection result with socket and metadata
  * @returns {net.Socket} returns.socket - Connected TCP socket

--- a/test/dane-test.js
+++ b/test/dane-test.js
@@ -308,9 +308,10 @@ module.exports.daneResolverError = test => {
 };
 
 /**
- * Test DANE with resolver error and verify:false allows connection
+ * Test that verify:false no longer bypasses DANE enforcement (RFC 7672) and
+ * that passing it logs a deprecation notice
  */
-module.exports.daneResolverErrorVerifyFalse = test => {
+module.exports.daneResolverErrorVerifyFalseStillEnforced = test => {
     let logMessages = [];
 
     const mockResolveTlsa = async () => {
@@ -344,11 +345,13 @@ module.exports.daneResolverErrorVerifyFalse = test => {
             }
         },
         (err, connection) => {
-            test.ifError(err);
-            test.ok(connection, 'Connection should exist when verify is false');
-            test.ok(connection.socket, 'Connection should have socket');
+            test.ok(err, 'verify:false must not bypass DANE enforcement');
+            test.ok(!connection, 'Connection should not exist');
+            test.equal(err.category, 'dane', 'Error category should be dane');
 
-            // Check that TLSA lookup failure was logged
+            const deprecationLog = logMessages.find(log => log.msg && log.msg.includes('dane.verify option is deprecated'));
+            test.ok(deprecationLog, 'Should log a deprecation notice for verify:false');
+
             const failLog = logMessages.find(log => log.msg === 'TLSA lookup failed');
             test.ok(failLog, 'Should log TLSA lookup failure');
             test.ok(failLog.error, 'Should include error message');
@@ -1182,9 +1185,12 @@ module.exports.createDaneVerifierE2EWrongTlsa = test => {
 };
 
 /**
- * Test createDaneVerifier with verify:false logs failure but returns undefined
+ * Test createDaneVerifier ignores verify:false and still fails closed
+ *
+ * RFC 7672 Section 2.2 makes verification failures fatal whenever usable
+ * TLSA records are present, so there is no log-only mode.
  */
-module.exports.createDaneVerifierVerifyFalseLogsButPasses = test => {
+module.exports.createDaneVerifierIgnoresVerifyFalse = test => {
     const { certDer, spkiDer } = generateTestCert();
     const rawPeerCert = makeRawPeerCert(certDer, spkiDer);
 
@@ -1204,7 +1210,8 @@ module.exports.createDaneVerifierVerifyFalseLogsButPasses = test => {
     });
 
     const result = verifier('mail.example.com', rawPeerCert);
-    test.equal(result, undefined, 'Should return undefined (pass) when verify is false');
+    test.ok(result instanceof Error, 'Should still return an error when verify is false');
+    test.equal(result.code, 'DANE_VERIFICATION_FAILED', 'Should report a verification failure');
 
     const failLog = logMessages.find(l => l.msg === 'DANE verification failed');
     test.ok(failLog, 'Should still log DANE verification failed');
@@ -1236,6 +1243,128 @@ module.exports.createDaneVerifierE2EX509Certificate = test => {
     const verifier = dane.createDaneVerifier(tlsaRecords, { verify: true, logger: () => {} });
     const result = verifier('mail.example.com', x509Cert);
     test.equal(result, undefined, 'Should return undefined (success) for X509Certificate with matching TLSA');
+    test.done();
+};
+
+//
+// A CA and an end-entity certificate that CA actually issued, used for the
+// DANE-TA (usage 2) tests below. Generated with a 100 year validity so they
+// do not expire out from under the suite.
+//
+const TA_CA_DER = Buffer.from(
+    'MIIDHTCCAgWgAwIBAgIUEzfEvuik2FH3KONZNbrXsLLiuKowDQYJKoZIhvcNAQELBQAwHTEbMBkGA1UEAwwSbXgtY29ubmVjdCBUZXN0IENBMCAXDTI2' +
+        'MDcyMTEwMzMwNVoYDzIxMjYwNjI3MTAzMzA1WjAdMRswGQYDVQQDDBJteC1jb25uZWN0IFRlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK' +
+        'AoIBAQDTBmW0OllNCaYdOicFrP76I/nVDD0OUG61FyBrizj2YYsaOV61Nm28hoRLyl/5mLJx9DW4b8b7mY87KGc87NXT5cRDJiXN/EEuVieZeixMLwIn' +
+        'pZqw51K+/acT0HJJUX6Nadk3/86Xo4X3nEfQPL/xJgiiBLBNpJRV1C6eH4T2Db9uXBX75l4fUL+oT58/hSGguyashzyE3g+3DRPIcpasI1bmP4cfv8Gi' +
+        't4m7LRLibPqXP4iJbHAjr4Xh8Dfvq1Sq/E2cT8tsL7nrEQ9ZVjpd09pl09s2P1pRLVynAnGKQ7I3LSeBWlK0L41OABIEy+ghjnjaTDgPap7S6og08Yv5' +
+        'AgMBAAGjUzBRMB0GA1UdDgQWBBS4SyQT7WjLroxzXK/eOP/Gc4GTrTAfBgNVHSMEGDAWgBS4SyQT7WjLroxzXK/eOP/Gc4GTrTAPBgNVHRMBAf8EBTAD' +
+        'AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBAomjape3xZkLXU/rl3+JY/2AF2mVE6DQDCkNeIeeMcXSdkyyO6N3miVi1XXk6M9tIQGTsB2naBaQIrGhiCePk' +
+        'yE0vMtMYKGa6ig+2cjzIKqtCd+vE9YSRweGEKiIG6DYVjUACCo0C37IyFnKtqP2p074/3eOBzgHW4wdYIXR3GYHJAuJuW/Px85h/s77GY9frJvecg93U' +
+        'IthlRu1b6L+hz8NtLr8LgIVqQEjdJlSXFyAK0qayMYYQpYDrjR4W+Qsg+2LFNfCa6MIPE20bqH8lXuDOZXiQyEeuYiMOSOeF/tFny/Z74Tz+Oana2GiD' +
+        '4HhD4xyU2idOxbOYw42+XOjc',
+    'base64'
+);
+
+const TA_LEAF_DER = Buffer.from(
+    'MIIDCjCCAfKgAwIBAgIUJEeZ42eIrDgzaP5cn3hXX+hc+a4wDQYJKoZIhvcNAQELBQAwHTEbMBkGA1UEAwwSbXgtY29ubmVjdCBUZXN0IENBMCAXDTI2' +
+        'MDcyMTEwMzMwNVoYDzIxMjYwNjI3MTAzMzA1WjAbMRkwFwYDVQQDDBBtYWlsLmV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC' +
+        'AQEAyRvizu5PbuRQtnmFakuEumA+lsmLvZGWUhQRyf6OhF7dMXUNkfQ/iAAhuNoUVIzjEzG/d6nmZJFg4YFCwqArT+Iv2f2wis+nRoIX588NdTDYiqeL' +
+        'yoZmjXVvlLENO9DceCubaRKtqEmz7LI+XLRGLGUER/bUJMmQ/FV2K/A/MLJHlMJKAba+m85xEmjGVKlCFscNZsHl5bAw2fVaknVytQlCnp3qjOwP6EUm' +
+        'w0h8deiPmMl+doa2T9N93f4aX3IjNaqrxxin94JxO+Shyeu/7Phd4kQ/XNFBGcMy/U41TVvre96zvJd/y3Y8RpBdYVplv+XpR7kM1Dibv2VfCXE0TwID' +
+        'AQABo0IwQDAdBgNVHQ4EFgQU08eGh9XiMdbfvNXPIJtv46bxQgYwHwYDVR0jBBgwFoAUuEskE+1oy66Mc1yv3jj/xnOBk60wDQYJKoZIhvcNAQELBQAD' +
+        'ggEBAG4UpmlkKa4Yj4Ak1jh3ejKwVEfSwRV22SqK2RpYLx5fj77eDim/PDCd60esnWW0bl3vvUfsMrGVnxJWbV57/ORcvvrrbnWitF2/cKzMfsbspQkK' +
+        '+0srbphSQdFESOuYrEOllPigjSEiT3xIUUHztlRMzvYRvr5UNXRhlU9rpyiVwpF44tW6rvJIIdag4j/Z1Gjo2H6Pw1iOW5ZbTMGj/W0LOByzvBpVwEqK' +
+        '5GOwe59o9t4KjzTotwod4fEBK1fkTX13cCwM74zFoKv6P9xvWEMkj4rffIL8CnuEFWrfMfgyV6eot+SJfjQag6sF0xOhmyzqFnkLmqqnBMwbLU7x3S8=',
+    'base64'
+);
+
+const TA_CA = new nodeCrypto.X509Certificate(TA_CA_DER);
+const TA_LEAF = new nodeCrypto.X509Certificate(TA_LEAF_DER);
+
+// TLSA record pinning the CA as trust anchor: usage 2, selector 1 (SPKI), mtype 1 (SHA-256)
+const TA_TLSA_RECORDS = [
+    {
+        usage: 2,
+        selector: 1,
+        mtype: 1,
+        cert: nodeCrypto
+            .createHash('sha256')
+            .update(TA_CA.publicKey.export({ type: 'spki', format: 'der' }))
+            .digest()
+    }
+];
+
+/**
+ * Test that createDaneVerifier forwards its third argument as the issuer chain,
+ * which is what makes DANE-TA (usage 2) verification possible
+ */
+module.exports.createDaneVerifierForwardsChainForDaneTa = test => {
+    const verifier = dane.createDaneVerifier(TA_TLSA_RECORDS, { logger: () => {} });
+
+    const withoutChain = verifier('mail.example.com', TA_LEAF);
+    test.ok(withoutChain instanceof Error, 'DANE-TA should fail when no chain is supplied');
+    test.equal(withoutChain.code, 'DANE_VERIFICATION_FAILED', 'Should report a verification failure');
+
+    const withChain = verifier('mail.example.com', TA_LEAF, [TA_CA]);
+    test.equal(withChain, undefined, 'DANE-TA should succeed when the issuing trust anchor is supplied in the chain');
+
+    test.done();
+};
+
+/**
+ * Test that DANE-TA works with the raw peer certificate shape returned by
+ * tls.getPeerCertificate(), not just X509Certificate instances
+ */
+module.exports.createDaneVerifierChainAcceptsRawPeerCerts = test => {
+    const verifier = dane.createDaneVerifier(TA_TLSA_RECORDS, { logger: () => {} });
+    const result = verifier('mail.example.com', { raw: TA_LEAF_DER }, [{ raw: TA_CA_DER }]);
+
+    test.equal(result, undefined, 'DANE-TA should succeed for raw peer certificate objects');
+    test.done();
+};
+
+/**
+ * Test that a DANE-TA record still fails when the chain contains no matching cert
+ */
+module.exports.createDaneVerifierChainWithoutMatchFails = test => {
+    const { certDer } = generateTestCert();
+
+    const verifier = dane.createDaneVerifier(TA_TLSA_RECORDS, { logger: () => {} });
+    const result = verifier('mail.example.com', TA_LEAF, [{ raw: certDer }]);
+
+    test.ok(result instanceof Error, 'Should fail when no chain certificate matches the TLSA record');
+    test.equal(result.code, 'DANE_VERIFICATION_FAILED', 'Should report a verification failure');
+    test.done();
+};
+
+/**
+ * Test that a DANE-TA match requires the pinned trust anchor to have actually
+ * issued the presented certificate.
+ *
+ * The trust anchor a TLSA record pins is public - it is sent in the clear by
+ * the real server on every handshake. If merely appearing in the chain were
+ * enough, an attacker could present a certificate of their own and staple the
+ * pinned CA onto the chain to have it accepted, which defeats the point of
+ * DANE entirely.
+ */
+module.exports.createDaneVerifierRejectsUnrelatedLeafWithPinnedCaInChain = test => {
+    // A self-signed certificate NOT issued by the pinned CA, standing in for
+    // the certificate an interception proxy would present
+    const { certDer } = generateTestCert();
+    const impostorLeaf = new nodeCrypto.X509Certificate(certDer);
+
+    test.equal(impostorLeaf.checkIssued(TA_CA), false, 'Impostor leaf must not actually be issued by the pinned CA');
+
+    const verifier = dane.createDaneVerifier(TA_TLSA_RECORDS, { logger: () => {} });
+    const result = verifier('mail.example.com', impostorLeaf, [TA_CA]);
+
+    test.ok(result instanceof Error, 'Must reject a leaf the pinned trust anchor did not issue');
+    test.equal(result.code, 'DANE_VERIFICATION_FAILED', 'Should report a verification failure');
+
+    // The pinned CA is not on the verified path (which is the leaf alone, since
+    // nothing in the chain issued it), so it is never considered a match
+    test.ok(result.message.includes('did not match'), 'Error should report that no TLSA record matched');
+
     test.done();
 };
 

--- a/test/dnssec-check-test.js
+++ b/test/dnssec-check-test.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const mxConnect = require('../lib/mx-connect');
-const { createMockSocket } = require('./test-utils');
+const { createMockSocket, createDnsError } = require('./test-utils');
 
 /**
  * Test: DNSSEC-secure zone proceeds to TLSA lookup
@@ -112,13 +112,15 @@ module.exports.insecureZoneSkipsTlsa = test => {
 };
 
 /**
- * Test: checkDnssecSecure failure assumes insecure (safe default)
+ * Test: checkDnssecSecure failure is a lookup failure, not "insecure"
  *
- * When checkDnssecSecure throws an error, the zone should be treated
- * as insecure and TLSA lookups should be skipped. This is the safe
- * default to avoid SERVFAIL-induced delivery failures.
+ * A DNS failure leaves the DNSSEC status unknown. Treating that as
+ * "insecure" would skip the TLSA lookup and silently bypass DANE on a
+ * transient error (e.g. a rate-limited resolver on a queue retry), so the
+ * MX is marked as a DANE lookup failure and the connection is rejected
+ * with a temporary error instead.
  */
-module.exports.dnssecCheckFailureAssumesInsecure = test => {
+function testDnssecCheckFailure(test, code) {
     let tlsaLookupCalled = false;
     let logMessages = [];
 
@@ -128,9 +130,7 @@ module.exports.dnssecCheckFailureAssumesInsecure = test => {
     };
 
     const mockCheckDnssecSecure = async () => {
-        const err = new Error('DNS resolution failed');
-        err.code = 'ESERVFAIL';
-        throw err;
+        throw createDnsError(code, `DNSSEC status lookup failed with ${code}`);
     };
 
     mxConnect(
@@ -158,20 +158,31 @@ module.exports.dnssecCheckFailureAssumesInsecure = test => {
             }
         },
         (err, connection) => {
-            test.ifError(err);
-            test.ok(connection, 'Connection should exist');
-            test.ok(connection.socket, 'Connection should have socket');
+            test.ok(err, `${code} from the DNSSEC check must not bypass DANE`);
+            test.ok(!connection, 'Connection should not exist');
+            test.equal(err.category, 'dane', 'Error category should be dane');
+            test.ok(err.temporary, 'Error should be temporary so the message is retried');
             test.ok(!tlsaLookupCalled, 'resolveTlsa should NOT be called when DNSSEC check fails');
 
             // Verify that the failure was logged
             const failLog = logMessages.find(log => log.msg && log.msg.includes('DNSSEC status check failed'));
             test.ok(failLog, 'Should log that DNSSEC check failed');
-            test.equal(failLog.code, 'ESERVFAIL', 'Log should include the error code');
+            test.equal(failLog.code, code, 'Log should include the error code');
 
             test.done();
         }
     );
-};
+}
+
+module.exports.dnssecCheckFailureRejectsConnection = test => testDnssecCheckFailure(test, 'ESERVFAIL');
+
+//
+// ENODATA/ENOTFOUND mean "no TLSA records" when they come from a TLSA lookup,
+// but from the DNSSEC check they only mean the zone status is unknown. Folding
+// them into the no-records case would reopen the DANE bypass.
+//
+module.exports.dnssecCheckNoDataRejectsConnection = test => testDnssecCheckFailure(test, 'ENOTFOUND');
+module.exports.dnssecCheckNxDomainRejectsConnection = test => testDnssecCheckFailure(test, 'ENODATA');
 
 /**
  * Test: Without checkDnssecSecure, TLSA lookup proceeds as normal


### PR DESCRIPTION
Supersedes #25 (thanks @titanism for the DNSSEC diagnosis, which was the right call).

## From #25

- **`isZoneDnssecSecure` no longer reports a failed DNSSEC check as "insecure."** A DNS failure leaves the zone status unknown; treating it as insecure skipped the TLSA lookup and silently downgraded to opportunistic TLS on any transient resolver error, such as a rate limit on a queue retry. The MX is now marked as a DANE lookup failure and the connection is rejected with a temporary error, so DANE stays enforced across retries.
- **`createDaneVerifier` accepts a certificate chain**, enabling DANE-TA (usage 2) and PKIX-TA (usage 0).
- **The `dane.verify` opt-out is removed.** RFC 7672 Section 2.2 makes verification failures fatal whenever usable TLSA records are present.

## Follow-up fixes

**Trust-anchor linkage (the significant one).** `verifyCertAgainstTlsa` accepted a DANE-TA/PKIX-TA record if *any* certificate in the chain matched it, never checking that certificate actually issued the presented leaf. That loop pre-existed but was unreachable, since `createDaneVerifier` never forwarded a chain — #25 forwards it and documents building one, which made it live.

A trust anchor is public: it is sent in the clear by the real server on every handshake. So an attacker could present a self-signed certificate of their own, staple the pinned CA onto the chain, and have it accepted. Reproduced before the fix:

```
Did the pinned CA issue the attacker leaf? false
  LOG: DANE verification succeeded DANE-TA
verifier result: ACCEPTED (undefined)
```

Now `buildVerifiedPath` walks leaf to issuers requiring `checkIssued` **and** signature verification at each hop, and fails closed if no path can be built. Verified: attack rejected, legitimate DANE-TA chains still accepted, both `X509Certificate` and raw `getPeerCertificate()` shapes work.

Note this is also reachable in released v1.6.0 via the exported `verifyCertAgainstTlsa(cert, tlsaRecords, chain)`, whose `chain` parameter is documented in JSDoc. DANE is experimental and unused, so no advisory.

**Other fixes:**

- Classify DNSSEC check failures separately from TLSA lookup failures. Reusing the TLSA "no records" classifier meant a DNSSEC check failing with `ENODATA`/`ENOTFOUND` would reopen the bypass #25 set out to close.
- Warn via `process.emitWarning` as well as the DANE logger on `verify: false`, once per process. The logger defaults to `null`, so callers most likely to still pass it would otherwise get no notice.
- Correct the README chain example. It documented `socket.getPeerCertificate(true)`, which returns a nested object rather than the array the verifier iterates, so DANE-TA would have failed for anyone following it. Also document that Node only invokes `checkServerIdentity` after its own PKIX validation passes.
- Narrow the verifier closure to capture only the logger rather than the whole DANE config, which pinned the caller's resolver callbacks for the connection's lifetime.
- Resolve the merge conflict against current master (#25 was two commits stale).

## Tests

#25 changed no tests, and three existing tests asserted the removed `verify: false` behavior, so the suite failed. Those are updated, and coverage added for the DNSSEC failure paths and trust-anchor linkage. **391 unit assertions pass**, up from 376. `prettier --check` and `eslint` clean.

`test/integration/mx-connect-integration-test.js` `policyFail` fails, but identically on clean master — a live-network MTA-STS check against zone.ee, unrelated.

## Versioning

`dane.verify` no longer disables enforcement. DANE is experimental, so this is deliberately **not** marked a breaking change and will cut a patch release.