### PR TITLE
docs(readme): correct the TLSA claims and restructure for reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # mx-connect
 
-Establish TCP connection to a MX server. This module takes a target domain or email address, resolves appropriate MX servers for this target and tries to get a connection, starting from higher priority servers.
+Establish a TCP connection to a mail server. Give it a domain or an email address; it resolves the MX records for that target and connects, trying the highest priority server first and falling back through the rest.
 
-Supports unicode hostnames, IPv6, MTA-STS, and DANE/TLSA verification.
+Supports unicode hostnames, IPv6, MTA-STS and DANE/TLSA verification.
+
+## Requirements
+
+Node.js 22.19.0 or newer. The floor comes from [mailauth](https://www.npmjs.com/package/mailauth), used for MTA-STS policy handling.
+
+## Install
 
 ```
 npm install mx-connect
@@ -13,25 +19,24 @@ npm install mx-connect
 ```javascript
 const mxConnect = require('mx-connect');
 
-// Using promises (recommended)
+// Promise (recommended)
 const connection = await mxConnect(options);
 
-// Using callbacks
+// Callback
 mxConnect(options, (err, connection) => { ... });
 ```
 
-Where
+- **options** is the target domain, an email address, or a configuration object
+- **callback** is optional; a promise is returned either way
 
-- **options** is the target domain, address, or configuration object
-- **callback** (optional) is the function to run once connection is established or it fails
-
-**Example using async/await**
+### Example
 
 ```javascript
 const mxConnect = require('mx-connect');
 
 try {
     const connection = await mxConnect('user@gmail.com');
+
     console.log('Connection to %s:%s', connection.hostname, connection.port);
     // Connection to aspmx.l.google.com:25
 
@@ -42,210 +47,287 @@ try {
 }
 ```
 
-**Example using callbacks**
+The same with a callback:
 
 ```javascript
-const mxConnect = require('mx-connect');
-
 mxConnect('user@gmail.com', (err, connection) => {
     if (err) {
-        console.error(err);
-    } else {
-        console.log('Connection to %s:%s', connection.hostname, connection.port);
-        // Connection to aspmx.l.google.com:25
+        return console.error(err);
+    }
+    console.log('Connection to %s:%s', connection.hostname, connection.port);
+});
+```
 
-        connection.socket.pipe(process.stdout);
-        // 220 mx.google.com ESMTP k11-v6si869487ljk.7 - gsmtp
+## Configuration
+
+Pass a string to use the defaults, or an object to configure. Every property except `target` is optional.
+
+### Target and connection
+
+| Option           | Type   | Default | Description                                                                                              |
+| ---------------- | ------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| `target`         | string |         | Domain, email address, IP address or IP address literal. Anything valid after an `@`. Unicode is allowed |
+| `port`           | number | `25`    | Port to connect to                                                                                       |
+| `maxConnectTime` | number | 5 min   | Timeout in milliseconds to establish a connection, applied per MX host                                   |
+
+### Local address binding
+
+| Option              | Description                                   |
+| ------------------- | --------------------------------------------- |
+| `localAddress`      | Local IP address to bind to                   |
+| `localHostname`     | Hostname of the local address, used for EHLO  |
+| `localAddressIPv4`  | Local address used only for IPv4 connections  |
+| `localHostnameIPv4` | Local hostname used only for IPv4 connections |
+| `localAddressIPv6`  | Local address used only for IPv6 connections  |
+| `localHostnameIPv6` | Local hostname used only for IPv6 connections |
+
+The family-specific options let you bind a different source address per family. `localAddress` is used as-is whenever it matches the family of the host being connected to; the matching family-specific option is used only when `localAddress` is unset, or when the host belongs to the other family.
+
+### dnsOptions
+
+| Option                  | Type     | Default       | Description                                                                                     |
+| ----------------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------- |
+| `ignoreIPv6`            | boolean  | `false`       | Never use IPv6 for sending. See [below](#ignoreipv6)                                            |
+| `preferIPv6`            | boolean  | `false`       | Try IPv6 addresses before IPv4 when a host has both                                             |
+| `blockLocalAddresses`   | boolean  | `false`       | Refuse local and private scope addresses. See [Address validation](#address-validation)         |
+| `blockReservedNetworks` | boolean  | `false`       | Refuse IANA special-purpose addresses. See [Address validation](#address-validation)            |
+| `nat64Prefixes`         | string[] | `[]`          | NAT64 prefixes your own network runs. See [NAT64 on your own prefix](#nat64-on-your-own-prefix) |
+| `resolve`               | function | `dns.resolve` | Custom callback-style DNS resolver                                                              |
+
+A custom `resolve` function is called as `resolve(domain, type, callback)`, except for A record lookups which always use `resolve(domain, callback)`. Other record types (`MX`, `AAAA`, `TXT`) always pass the type.
+
+#### ignoreIPv6
+
+With `ignoreIPv6` enabled, no AAAA records are looked up and any IPv6 address is refused rather than used, including one given as the target or supplied through `mx`. A host that also has an IPv4 address is still delivered to over IPv4.
+
+> [!NOTE]
+> Refusing an address for this reason says nothing about the destination, only about how you configured this sender, so the error is marked temporary. A message waits for the setting to change instead of bouncing.
+
+### mx
+
+Skip MX resolution and connect to a host you name. Accepts a hostname string, a resolved MX object, or an array of either. A string is treated as a hostname or IP address with priority 0.
+
+| Property      | Description                                                            |
+| ------------- | ---------------------------------------------------------------------- |
+| `exchange`    | Hostname of the MX                                                     |
+| `priority`    | MX priority, defaulting to `0`. Lower numbers are tried first          |
+| `A`           | Array of IPv4 addresses. Resolved from `exchange` when omitted         |
+| `AAAA`        | Array of IPv6 addresses. Resolved from `exchange` when omitted         |
+| `tlsaRecords` | Pre-resolved TLSA records. Resolved automatically when DANE is enabled |
+
+> [!IMPORTANT]
+> Addresses you supply here are validated exactly like resolved ones. An `mx` entry pointing at a blocked address is refused, not connected to.
+
+### Host filtering and hooks
+
+| Option          | Type     | Description                                                         |
+| --------------- | -------- | ------------------------------------------------------------------- |
+| `ignoreMXHosts` | string[] | IP addresses to skip when connecting                                |
+| `mxLastError`   | Error    | Error to report if `ignoreMXHosts` filters out every host           |
+| `connectHook`   | function | `(delivery, options, callback)`, run before each connection attempt |
+| `connectError`  | function | `(err, delivery, options)`, run when a connection to an MX fails    |
+
+`connectHook` runs before the TCP connection is opened. If `options` has a `socket` property once the callback returns, mx-connect uses that socket instead of connecting itself. This is how you divert a connection, for example through a SOCKS proxy for an Onion target.
+
+### mtaSts
+
+| Option           | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| `enabled`        | Set to `true` to run MTA-STS checks. Off by default       |
+| `logger(logObj)` | Receives MTA-STS log entries. Logging is off by default   |
+| `cache`          | Policy cache with `get(domain)` and `set(domain, policy)` |
+
+### dane
+
+| Option                    | Description                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| `enabled`                 | Must be set to `true` to enable DANE. There is no auto-detection                            |
+| `resolveTlsa(tlsaName)`   | Optional custom TLSA resolver. See [Custom TLSA resolver](#custom-tlsa-resolver)            |
+| `checkDnssecSecure(host)` | Optional DNSSEC status check. See [DNSSEC-aware DANE](#dnssec-aware-dane)                   |
+| `logger(logObj)`          | Receives DANE log entries. Logging is off by default                                        |
+| `verify`                  | Deprecated and ignored. DANE is always enforced when TLSA records are present, per RFC 7672 |
+
+See [DANE support](#dane-support) for the full picture.
+
+## Address validation
+
+People put every kind of thing in MX records. You do not want to flood your loopback interface because someone decided `127.0.0.1` was a good MX host.
+
+Every address the library resolves or is given passes through one check, whatever its origin: DNS answers, addresses you pass through `mx`, an IP literal target, and the host a domain's MTA-STS policy is fetched from.
+
+### Always refused
+
+These can never be a real mail host and are refused whatever the options say.
+
+| Range                     | Description         |
+| ------------------------- | ------------------- |
+| `0.0.0.0`, `::`           | Unspecified address |
+| `255.255.255.255`         | Limited broadcast   |
+| `224.0.0.0/4`, `ff00::/8` | Multicast           |
+| `100::/64`                | Discard prefix      |
+| `5f00::/16`               | Segment routing     |
+
+### blockLocalAddresses
+
+| Range                         | Description                 |
+| ----------------------------- | --------------------------- |
+| `127.0.0.0/8`, `::1`          | Loopback                    |
+| RFC 1918 ranges               | Private networks            |
+| `169.254.0.0/16`, `fe80::/10` | Link-local                  |
+| `100.64.0.0/10`               | Carrier-grade NAT           |
+| `fc00::/7`                    | IPv6 unique-local           |
+| `fec0::/10`                   | Deprecated site-local       |
+| `64:ff9b:1::/48`              | Local-use NAT64 (see below) |
+
+Any address assigned to one of the machine's own interfaces is refused too.
+
+`64:ff9b:1::/48` is refused wholesale because RFC 8215 leaves the position of the embedded IPv4 address up to the local network, so it cannot be read from the address. Declaring the prefix in `nat64Prefixes` supplies that missing piece and lifts the blanket refusal.
+
+### blockReservedNetworks
+
+Off by default so the documentation ranges stay usable in tests and staging.
+
+| Range                                                                | Description   |
+| -------------------------------------------------------------------- | ------------- |
+| `240.0.0.0/4`                                                        | Future use    |
+| `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32` | Documentation |
+| `198.18.0.0/15`, `2001:2::/48`                                       | Benchmarking  |
+| `2001:3::/32`                                                        | AMT           |
+
+### Canonical notation is required
+
+An address has to be written in a notation `net.isIP()` recognises, so `0127.0.0.1`, `2130706433` and `127.1` are refused rather than checked.
+
+> [!WARNING]
+> Those spellings mean different things to different parsers. A leading zero is octal to one and decimal to another, so `0127.0.0.1` would be checked as the public `87.0.0.1` and then connected to `127.0.0.1`.
+
+Records returned by `dns.resolve` are always canonical, so this only concerns addresses you supply through `mx` or a custom `resolve` function.
+
+### IPv4 addresses carried inside IPv6
+
+Several IPv6 forms carry an IPv4 address that the connection actually reaches. Each is judged as the address it reaches, so it can neither slip past `blockLocalAddresses` nor be refused when the host behind it is an ordinary public one.
+
+| Form             | Example            |
+| ---------------- | ------------------ |
+| IPv4-mapped      | `::ffff:127.0.0.1` |
+| IPv4-compatible  | `::127.0.0.1`      |
+| NAT64 well-known | `64:ff9b::/96`     |
+| IPv4-translated  | `::ffff:0:0:0/96`  |
+| 6to4             | `2002::/16`        |
+| Teredo           | `2001::/32`        |
+
+So `64:ff9b::7f00:1` is refused because it reaches `127.0.0.1`, while `64:ff9b::8.8.8.8` is fine. That distinction matters on IPv6-only networks, where DNS64 synthesizes exactly these records for every IPv4-only mail host, and blocking the prefix outright would break delivery to all of them.
+
+For 6to4 and Teredo both tunnel endpoints are checked as well as the address itself.
+
+> [!NOTE]
+> `ignoreIPv6` is decided separately from this unwrapping, because it is about which stack the socket uses rather than where the packets land. `::ffff:8.8.8.8` and `64:ff9b::8.8.8.8` are refused as IPv6 even though they reach an IPv4 host.
+
+### NAT64 on your own prefix
+
+RFC 6052 also lets a network run NAT64 on a prefix from its own address space. Nothing in such an address identifies it as one, so `2a01:4f8:c17:b8f::7f00:1` is indistinguishable from an ordinary IPv6 host.
+
+Only you know that prefix. Declare it and the address it carries is checked like any other:
+
+```javascript
+const connection = await mxConnect({
+    target: 'user@example.com',
+    dnsOptions: {
+        blockLocalAddresses: true,
+        nat64Prefixes: ['2a01:4f8:c17:b8f::/96']
     }
 });
 ```
 
-### Configuration options
+[RFC 7050](https://datatracker.ietf.org/doc/html/rfc7050) describes how to discover the prefix your network uses. Only the prefix lengths RFC 6052 defines (32, 40, 48, 56, 64 and 96) place the address at a known position, so an entry with any other length is ignored, as is one that cannot be parsed.
 
-You can use a domain name or an email address as the target, for additional configuration you would need to use a configuration object with the following properties (most are optional)
+### Seeing what was refused
 
-- **target** is either a domain name or an email address or an IP address or IP address literal (basically anything you can have after the @-sign in an email address). Unicode is allowed.
+Refused addresses are collected on `delivery.blockedAddresses`, which is passed to the `connectHook` and `connectError` callbacks. Each entry has `exchange`, `ip` and `reason`.
 
-- **port** is the port number to connect to. Defaults to 25.
-- **maxConnectTime** is the timeout in milliseconds to wait for a connection to be established (per MX host). Defaults to 5 minutes.
-- **localAddress** is the local IP address to use for the connection
-- **localHostname** is the hostname of the local address
-- **localAddressIPv4** is the local IPv4 address to use for the connection if you want to specify an address both for IPv4 and IPv6
-- **localHostnameIPv4** is the local hostname to use for IPv4 connections
-- **localAddressIPv6** is the local IPv6 address to use for the connection if you want to specify an address both for IPv4 and IPv6
-- **localHostnameIPv6** is the local hostname to use for IPv6 connections
-- **dnsOptions** is an object for IP address related options
-    - **ignoreIPv6** (boolean, defaults to `false`) If true then IPv6 is never used for sending: no AAAA records are looked up, and any IPv6 address is refused rather than used, including ones given as the target or supplied through the **mx** option. A host that also has an IPv4 address is still delivered to over IPv4. Because this refusal reflects your configuration rather than the destination, the resulting error is temporary, so a message is held rather than bounced
-    - **preferIPv6** (boolean, defaults to `false`) If true then use IPv6 address even if IPv4 address is also available
-    - **blockLocalAddresses** (boolean, defaults to `false`) If true then refuses to connect to IP addresses that are in a local or private scope, or attached to the server. People put every kind of stuff in MX records, you do not want to flood your loopback interface because someone thought it is a great idea to set 127.0.0.1 as the MX server. Covers loopback (`127.0.0.0/8`, `::1`), private networks (RFC1918), link-local (`169.254.0.0/16`, `fe80::/10`), carrier-grade NAT (`100.64.0.0/10`), IPv6 unique-local (`fc00::/7`) and deprecated site-local (`fec0::/10`). Also covers the local-use NAT64 prefix (`64:ff9b:1::/48`), whose embedded IPv4 address depends on the local network configuration and so cannot be checked
-    - **blockReservedNetworks** (boolean, defaults to `false`) If true then also refuses to connect to IANA special-purpose addresses: future-use (`240.0.0.0/4`), the documentation ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32`), benchmarking (`198.18.0.0/15`, `2001:2::/48`) and AMT (`2001:3::/32`). Off by default so that the documentation ranges stay usable in tests and staging setups
-    - **nat64Prefixes** (array of CIDR strings, defaults to `[]`) The NAT64 prefixes your network runs, for example `['2a01:4f8:c17:b8f::/96']`. The well-known prefix `64:ff9b::/96` is always recognised; a prefix from your own address space cannot be, since nothing in the address identifies it. Declaring it lets the IPv4 address such an address carries be validated like any other, so a synthesized record pointing at `127.0.0.1` is refused while one pointing at a public host still delivers, and the address is still judged on its own account as well. RFC 7050 describes how to discover the prefix your network uses. Only the prefix lengths RFC 6052 defines (32, 40, 48, 56, 64 and 96) carry an address at a known position, so an entry with any other length is ignored, as is one that cannot be parsed
-    - **resolve** (function, defaults to native `dns.resolve`) Custom callback-style DNS resolver function with signature `resolve(domain, type, callback)` or `resolve(domain, callback)`. A record lookups always use the two-argument form `resolve(domain, callback)`, other record types (`MX`, `AAAA`, `TXT`) use the three-argument form
+This matters when only some of a host's addresses are refused: delivery continues over whatever survived, and without this the filtering would leave no trace, so a host left with only unreachable addresses would look like a plain network failure.
 
-    Addresses that can never be a real mail host are always rejected, whatever the options above are set to: the unspecified address (`0.0.0.0`, `::`), the limited broadcast address (`255.255.255.255`), multicast (`224.0.0.0/4`, `ff00::/8`), the discard prefix (`100::/64`) and segment routing identifiers (`5f00::/16`).
+> [!CAUTION]
+> `connectHook` receives the same options object used to open the socket, so a hook that rewrites `options.host` connects wherever it says. That is by design, and it is the one path validation does not cover.
 
-    An address also has to be written in a notation `net.isIP()` recognises, so `0127.0.0.1`, `2130706433` and `127.1` are refused rather than checked. Those spellings mean different things to different parsers, and the platform resolver would reach a different host than the one checked: a leading zero is octal here and decimal there, which would turn `0127.0.0.1` into a check against the public `87.0.0.1` and a connection to `127.0.0.1`. Records returned by `dns.resolve` are always canonical, so this only concerns addresses you supply through the **mx** option or a custom **resolve** function.
+## Connection object
 
-    An IPv6 address that carries an IPv4 address inside it is judged as the IPv4 address the connection actually reaches, so it can neither slip past `blockLocalAddresses` nor be refused when the host it reaches is an ordinary public one. This covers IPv4-mapped (`::ffff:127.0.0.1`), the deprecated IPv4-compatible form (`::127.0.0.1`), NAT64 (`64:ff9b::/96`), IPv4-translated (`::ffff:0:0:0/96`), 6to4 (`2002::/16`) and Teredo (`2001::/32`). So `64:ff9b::7f00:1` is refused because it reaches `127.0.0.1`, while `64:ff9b::8.8.8.8` is fine - which matters on IPv6-only networks, where DNS64 synthesizes exactly these records for every IPv4-only mail host. For 6to4 and Teredo both tunnel endpoints are checked as well as the address itself. `ignoreIPv6` is decided separately from this unwrapping, since it is about which stack the socket uses rather than where the packets land, so `::ffff:8.8.8.8` and `64:ff9b::8.8.8.8` are still refused as IPv6 even though they reach an IPv4 host.
+The promise resolves, or the callback is invoked, with:
 
-    RFC 6052 also lets a network run NAT64 on a prefix out of its own address space, and nothing in such an address marks it as one, so `2a01:4f8:c17:b8f::7f00:1` is indistinguishable from an ordinary IPv6 host. Only you know that prefix, so declare it with **nat64Prefixes** and the address it carries is checked like any other.
+| Property        | Description                                                            |
+| --------------- | ---------------------------------------------------------------------- |
+| `socket`        | Connected socket                                                       |
+| `hostname`      | Hostname of the exchange                                               |
+| `host`          | IP address connected to                                                |
+| `port`          | Port connected to                                                      |
+| `localAddress`  | Local IP address used                                                  |
+| `localHostname` | Local hostname used                                                    |
+| `localPort`     | Local port used                                                        |
+| `daneEnabled`   | `true` when DANE is active for this connection                         |
+| `daneVerifier`  | DANE certificate verification function, for use during the TLS upgrade |
+| `tlsaRecords`   | TLSA records for this MX host, when DANE is enabled                    |
+| `requireTls`    | `true` when TLSA records exist, indicating TLS should be enforced      |
 
-    All of the above, `ignoreIPv6` included, is decided in one place for every address the library resolves or is given, including addresses you pass in yourself through the **mx** option and the host a domain's MTA-STS policy is fetched from. The one exception is **connectHook**: it is handed the same options object used to open the socket, so a hook that rewrites `options.host` connects wherever it says, by design. Addresses dropped by these rules are listed on the `delivery.blockedAddresses` array handed to the `connectHook` and `connectError` callbacks, so filtering that still leaves a usable address can be told apart from a network failure.
+> [!IMPORTANT]
+> mx-connect does not enforce TLS itself. Check `requireTls` during your TLS upgrade.
 
-- **mx** is a hostname string, a resolved MX object, or an array of either, to skip DNS resolving. Useful if you want to connect to a specific host. String entries are treated as hostnames (or IP addresses) with priority 0.
-    - **exchange** is the hostname of the MX
-    - **priority** (defaults to 0) is the MX priority number that is used to sort available MX servers (servers with higher priority are tried first)
-    - **A** is an array of IPv4 addresses. Optional, resolved from exchange hostname if not set
-    - **AAAA** is an array of IPv6 addresses. Optional, resolved from exchange hostname if not set
-    - **tlsaRecords** is an array of pre-resolved TLSA records for DANE verification. Optional, resolved automatically if DANE is enabled
-- **ignoreMXHosts** is an array of IP addresses to skip when connecting
-- **mxLastError** is an error object to use if all MX hosts are filtered out by `ignoreMXHosts`
-- **connectHook** _function (delivery, options, callback)_ is a function handler to run before establishing a tcp connection to current target (defined in `options`). If the `options` object has a `socket` property after the callback then connection is not established. Useful if you want to divert the connection in some cases, for example if the target domain is in the Onion network then you could create a socket against a SOCKS proxy yourself.
-- **connectError** _function (err, delivery, options)_ is a function handler to run when a connection to a MX fails.
-- **mtaSts** is an object for MTA-STS configuration
-    - **enabled** - if not `true` then does not run MTA-STS checks, disabled by default
-    - **logger(logObj)** - method to log MTA-STS information, logging is disabled by default
-    - **cache** - an object to manage MTA-STS policy cache
-        - **get(domain)** -> returns cached policy object
-        - **set(domain, policyObj)** -> caches a policy object
-- **dane** is an object for DANE/TLSA configuration (see [DANE Support](#dane-support) section below)
-    - **enabled** - must be set to `true` to enable DANE verification
-    - **resolveTlsa(tlsaName)** - custom async function to resolve TLSA records. Receives the full TLSA query name (e.g., `_25._tcp.mail.example.com`). If not provided, uses native `dns.resolveTlsa` when available
-    - **checkDnssecSecure(hostname)** - optional async function to check DNSSEC validation status of an MX host before attempting TLSA lookups ([RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2)). Should return `{ secure: boolean }`. When provided and the zone is insecure, TLSA lookups are skipped and the connection falls back to opportunistic TLS. See [DNSSEC-Aware DANE](#dnssec-aware-dane) below
-    - **logger(logObj)** - method to log DANE information, logging is disabled by default
-    - **verify** - _(deprecated, ignored)_ DANE verification is always enforced when TLSA records are present, per RFC 7672. This option is accepted for backward compatibility but has no effect
+## Null MX
 
-### Null MX
+A domain that publishes an [RFC 7505](https://datatracker.ietf.org/doc/html/rfc7505) null MX record (`0 .`) is stating that it accepts no mail at all. Resolving such a target fails permanently with `err.code = 'ENULLMX'` and no A/AAAA fallback is attempted. Treat it as a permanent rejection; retrying will not help.
 
-If a domain publishes an [RFC 7505](https://datatracker.ietf.org/doc/html/rfc7505) null MX record (`0 .`), it states that it accepts no mail at all. Resolving such a target fails permanently with `err.code = 'ENULLMX'`, and no fallback to A/AAAA records is attempted. Treat it as a permanent rejection, there is no point in retrying it later.
+A null MX published alongside real MX records is a misconfiguration, forbidden by RFC 7505 Section 4.1. The null entry is ignored and delivery proceeds over the remaining records.
 
-A null MX published alongside real MX records is a misconfiguration, RFC 7505 Section 4.1 forbids the combination. In that case the null entry is ignored and delivery proceeds using the remaining MX records.
+## DANE support
 
-### Connection object
+DANE (DNS-based Authentication of Named Entities) authenticates TLS certificates through DNSSEC. mx-connect looks up TLSA records for each MX host and gives you a verifier for the server certificate.
 
-Function callback or promise resolution provides a connection object with the following properties:
-
-- **socket** is a socket object against target
-- **hostname** is the hostname of the exchange
-- **host** is the IP address of the exchange
-- **port** is the port used to connect
-- **localAddress** is the local IP address used for the connection
-- **localHostname** is the local hostname used for the connection
-- **localPort** is the local port used for the connection
-- **daneEnabled** is `true` if DANE verification is active for this connection
-- **daneVerifier** is the DANE certificate verification function (for use during TLS upgrade)
-- **tlsaRecords** is an array of TLSA records for this MX host (if DANE is enabled)
-- **requireTls** is `true` when DANE records exist, indicating TLS should be enforced. mx-connect itself does not enforce TLS -- the consuming application should check this flag during TLS upgrade
-
-## DANE Support
-
-DANE (DNS-based Authentication of Named Entities) provides a way to authenticate TLS certificates using DNSSEC. This module supports DANE verification for outbound SMTP connections by looking up TLSA records and verifying server certificates against them.
-
-### Security Considerations
-
-> **Important**: DANE security relies on DNSSEC validation. Without DNSSEC, a DNS attacker could potentially inject fake TLSA records and pin a malicious certificate, introducing new security vulnerabilities rather than preventing them.
-
-Currently, Node.js does not expose the DNSSEC AD (Authenticated Data) flag from DNS responses, which means applications cannot verify that TLSA records were DNSSEC-validated by the resolver. This is tracked in [nodejs/node#57159](https://github.com/nodejs/node/issues/57159).
-
-However, applications that use a DNS-over-HTTPS (DoH) resolver or a custom DNS library with access to raw DNS response packets can check the AD flag themselves. The `dane.checkDnssecSecure` callback provides a way to integrate this check into the DANE pipeline, allowing mx-connect to skip TLSA lookups for MX hosts whose zones are not DNSSEC-signed. This prevents delivery failures caused by nameservers that return SERVFAIL for TLSA queries on unsigned zones (see [RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2) and [DNSSEC-Aware DANE](#dnssec-aware-dane) below).
-
-**Recommendations for production use:**
-
-1. **Use a DNSSEC-validating resolver** - Configure your system to use a resolver that performs DNSSEC validation (e.g., Cloudflare's 1.1.1.1, Google's 8.8.8.8, or a local validating resolver like Unbound)
-2. **Use DNS-over-HTTPS (DoH)** - A DoH resolver provides transport security via HTTPS, which protects against on-path attackers (though this is not a substitute for DNSSEC validation)
-3. **Use `checkDnssecSecure`** - If your DNS resolver exposes the AD flag (e.g., via DoH raw responses), provide a `checkDnssecSecure` callback to skip TLSA lookups for insecure zones per RFC 7672
-4. **Monitor [nodejs/node#57159](https://github.com/nodejs/node/issues/57159)** - When Node.js adds AD flag support, this module will be updated to optionally require DNSSEC validation
-
-For domains with properly configured DNSSEC, DANE provides strong protection against certificate misissuance and man-in-the-middle attacks. For domains without DNSSEC, consider using MTA-STS as an alternative or complementary security mechanism.
-
-### Node.js Version Support
-
-Node.js 22.19.0 or newer is required. The floor comes from `mailauth`, which this package depends on for MTA-STS policy handling.
-
-Native `dns.resolveTlsa`, used for DANE, is available across that whole range:
-
-| Node.js Version | TLSA Support |
-| --------------- | ------------ |
-| v24.x           | Native       |
-| v23.9.0+        | Native       |
-| v22.19.0+       | Native       |
-
-**Note:** `dane.enabled` must be set to `true` explicitly to activate DANE. There is no auto-detection. A custom resolver can still be supplied through the `dane.resolveTlsa` option if you want to route TLSA lookups through your own validating resolver.
-
-### Custom TLSA Resolver
-
-For Node.js versions without native TLSA support, you can provide a custom resolver function:
+Native `dns.resolveTlsa` is available on every Node.js version this package supports, so DANE needs no resolver configuration:
 
 ```javascript
-const mxConnect = require('mx-connect');
-
 const connection = await mxConnect({
     target: 'user@example.com',
-    dane: {
-        enabled: true,
-        resolveTlsa: customResolveTlsa,
-        logger: console.log
-    }
+    dane: { enabled: true, logger: console.log }
 });
 
-console.log('Connected to %s:%s', connection.hostname, connection.port);
 console.log('DANE enabled:', connection.daneEnabled);
-
-if (connection.tlsaRecords) {
-    console.log('TLSA records:', connection.tlsaRecords.length);
-}
-
-// Use connection.daneVerifier during TLS upgrade
-// The verifier function can be passed to tls.connect() as checkServerIdentity
+console.log('TLSA records:', connection.tlsaRecords?.length ?? 0);
 ```
 
-### DNSSEC-Aware DANE
+> [!NOTE]
+> `dane.enabled` must be set to `true` explicitly. There is no auto-detection.
 
-[RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2) requires SMTP clients to check the DNSSEC validation status of MX host address records before attempting TLSA lookups. If the zone is not DNSSEC-signed ("insecure"), TLSA lookups should be skipped because:
+### Security considerations
 
-1. Secure TLSA records cannot exist in an unsigned zone
-2. Some nameservers for unsigned zones return SERVFAIL for TLSA queries (e.g., Microsoft Exchange Online Protection), which would cause delivery failures
+> [!IMPORTANT]
+> DANE security rests on DNSSEC validation. Without it, an attacker who can tamper with DNS could inject fake TLSA records and pin a certificate of their choosing, making things worse rather than better.
 
-The `checkDnssecSecure` callback enables this check. It receives an MX hostname and should return `{ secure: boolean }` indicating whether the zone is DNSSEC-signed.
+Node.js does not currently expose the DNSSEC AD (Authenticated Data) flag from DNS responses, so an application cannot confirm that TLSA records were DNSSEC-validated by the resolver. This is tracked in [nodejs/node#57159](https://github.com/nodejs/node/issues/57159).
 
-```javascript
-const mxConnect = require('mx-connect');
+Applications using a DNS-over-HTTPS resolver, or any DNS library with access to raw response packets, can check the AD flag themselves and feed the result in through [`checkDnssecSecure`](#dnssec-aware-dane).
 
-const connection = await mxConnect({
-    target: 'user@example.com',
-    dane: {
-        enabled: true,
-        resolveTlsa: customResolveTlsa,
-        // RFC 7672 Section 2.2.2: Check DNSSEC status before TLSA lookups.
-        // Uses the AD (Authenticated Data) flag from the DNS response to
-        // determine if the MX host's zone is DNSSEC-signed.
-        async checkDnssecSecure(hostname) {
-            try {
-                // Check A record first (covers most MX hosts)
-                return await resolver.resolve(hostname, 'A', { dnssecSecure: true });
-            } catch {
-                // Fall back to AAAA for IPv6-only hosts
-                return resolver.resolve(hostname, 'AAAA', { dnssecSecure: true });
-            }
-        },
-        logger: console.log
-    }
-});
-```
+For production use:
 
-When `checkDnssecSecure` reports that a zone is insecure (`{ secure: false }`), mx-connect skips the TLSA lookup for that MX host and falls back to opportunistic TLS. If the callback itself throws an error (e.g. DNS timeout), the MX is marked as having a DANE lookup failure and the connection is rejected with a temporary error, preserving DANE enforcement across retries. If `checkDnssecSecure` is not provided, the existing behavior is preserved and TLSA lookups are attempted for all MX hosts.
+1. **Use a DNSSEC-validating resolver**, such as a local Unbound instance, or 1.1.1.1 or 8.8.8.8
+2. **Consider DNS-over-HTTPS** for transport security against on-path attackers, though it is not a substitute for DNSSEC validation
+3. **Provide `checkDnssecSecure`** if your resolver exposes the AD flag, so TLSA lookups are skipped for insecure zones per RFC 7672
+4. **Watch [nodejs/node#57159](https://github.com/nodejs/node/issues/57159)**; when Node exposes the AD flag, this module will be able to require DNSSEC validation
 
-### DANE Verification Flow
+For domains with DNSSEC configured, DANE protects strongly against certificate misissuance and interception. For domains without it, MTA-STS is the alternative or complement.
 
-When DANE is enabled, the following flow occurs:
+### Verification flow
 
-1. **DNSSEC Check** (optional): If `checkDnssecSecure` is provided, the DNSSEC validation status of each MX host's A/AAAA records is checked. Hosts in insecure zones (`{ secure: false }`) skip directly to step 5. If the check itself fails (DNS error), the MX is marked as a DANE lookup failure and the connection is rejected with a temporary error
-2. **TLSA Lookup**: For hosts in DNSSEC-signed zones (or when `checkDnssecSecure` is not provided), mx-connect resolves TLSA records for each MX hostname (e.g., `_25._tcp.mail.example.com`)
-3. **Connection**: A TCP connection is established to the MX server
-4. **TLS Upgrade**: When upgrading to TLS (STARTTLS), use the `connection.daneVerifier` function as the `checkServerIdentity` option
-5. **Certificate Verification**: The server's certificate is verified against the TLSA records (or opportunistic TLS is used if no TLSA records were found)
+1. **DNSSEC check**, if `checkDnssecSecure` is provided. Hosts in insecure zones skip to step 5. A failing check marks the host as a DANE lookup failure and rejects the connection with a temporary error
+2. **TLSA lookup** for each MX hostname, for example `_25._tcp.mail.example.com`
+3. **Connection** to the MX server
+4. **TLS upgrade**, where you pass `connection.daneVerifier` as `checkServerIdentity`
+5. **Certificate verification** against the TLSA records, or opportunistic TLS when none were found
 
-`connection.daneVerifier` has the signature `(hostname, cert, chain)`. Node only ever calls `checkServerIdentity` with `(hostname, cert)`, so the leaf certificate alone is checked when it is wired up as shown above - enough for DANE-EE (usage 3) and PKIX-EE (usage 1). To also cover DANE-TA (usage 2) and PKIX-TA (usage 0), call the verifier yourself after the handshake and pass the issuer chain as an **array of `X509Certificate` objects**:
+> [!WARNING]
+> Node only calls `checkServerIdentity` after its own PKIX validation passes, so with the default `rejectUnauthorized: true` a certificate failing PKIX is rejected before the DANE verifier ever runs. DANE-EE certificates are frequently self-signed, which is exactly what PKIX rejects. Set `rejectUnauthorized: false` and treat the verifier's result as the authority.
+>
+> When TLSA records are present, the verifier's return value is then the only thing standing between you and an intercepted connection. Always destroy the socket when it returns an error.
+
+`connection.daneVerifier` has the signature `(hostname, cert, chain)`. Node only ever calls `checkServerIdentity` with `(hostname, cert)`, so wiring it up directly checks the leaf certificate alone, which covers DANE-EE (usage 3) and PKIX-EE (usage 1). To also cover DANE-TA (usage 2) and PKIX-TA (usage 0), call the verifier yourself after the handshake and pass the issuer chain as an array of `X509Certificate` objects:
 
 ```javascript
 const leaf = socket.getPeerX509Certificate();
@@ -263,43 +345,97 @@ if (err) {
 }
 ```
 
-Two caveats when relying on DANE:
+### DNSSEC-aware DANE
 
-- Node only invokes `checkServerIdentity` after its own PKIX validation has passed, so with the default `rejectUnauthorized: true` a certificate that fails PKIX is rejected before the DANE verifier ever runs. DANE-EE certificates are frequently self-signed, which is exactly the case PKIX rejects. Set `rejectUnauthorized: false` and treat the verifier's result as the authority.
-- Because of the above, when TLSA records are present the verifier's return value is the only thing standing between you and an intercepted connection. Always destroy the socket when it returns an error, as shown.
+[RFC 7672 Section 2.2.2](https://datatracker.ietf.org/doc/html/rfc7672#section-2.2.2) requires SMTP clients to check the DNSSEC status of an MX host's address records before looking up TLSA records. TLSA lookups should be skipped for unsigned zones because:
 
-### TLSA Record Format
+1. Secure TLSA records cannot exist in an unsigned zone
+2. Some nameservers for unsigned zones return SERVFAIL for TLSA queries, Microsoft Exchange Online Protection among them, which would break delivery
 
-TLSA records returned by the resolver should have the following structure:
+`checkDnssecSecure` receives an MX hostname and returns `{ secure: boolean }`:
+
+```javascript
+const connection = await mxConnect({
+    target: 'user@example.com',
+    dane: {
+        enabled: true,
+        // Uses the AD flag from the DNS response to decide whether the
+        // MX host's zone is DNSSEC-signed
+        async checkDnssecSecure(hostname) {
+            try {
+                // A records cover most MX hosts
+                return await resolver.resolve(hostname, 'A', { dnssecSecure: true });
+            } catch {
+                // Fall back to AAAA for IPv6-only hosts
+                return resolver.resolve(hostname, 'AAAA', { dnssecSecure: true });
+            }
+        },
+        logger: console.log
+    }
+});
+```
+
+A zone reported insecure skips the TLSA lookup for that host and falls back to opportunistic TLS. If the callback itself throws, say on a DNS timeout, the host is marked as a DANE lookup failure and the connection is rejected with a temporary error, which keeps DANE enforced across retries rather than silently downgrading. Omitting the callback attempts TLSA lookups for every host.
+
+### Custom TLSA resolver
+
+> [!TIP]
+> You do not need this for compatibility. Every supported Node.js version resolves TLSA records natively. Supply one only when you want the lookups to go through a resolver of your own, typically to obtain DNSSEC validation.
+
+The function receives the full query name and returns an array of TLSA records:
+
+```javascript
+const connection = await mxConnect({
+    target: 'user@example.com',
+    dane: {
+        enabled: true,
+        async resolveTlsa(tlsaName) {
+            // tlsaName is e.g. '_25._tcp.mail.example.com'
+            const answers = await myDohResolver.query(tlsaName, 'TLSA');
+
+            return answers.map(answer => ({
+                usage: answer.usage,
+                selector: answer.selector,
+                mtype: answer.matchingType,
+                cert: Buffer.from(answer.certificate, 'hex')
+            }));
+        }
+    }
+});
+```
+
+Return an empty array when the host publishes no TLSA records.
+
+### TLSA record format
 
 ```javascript
 {
-    usage: 3,           // 0=PKIX-TA, 1=PKIX-EE, 2=DANE-TA, 3=DANE-EE
-    selector: 1,        // 0=Full certificate, 1=SubjectPublicKeyInfo
-    mtype: 1,           // 0=Full data, 1=SHA-256, 2=SHA-512
-    cert: Buffer,       // Certificate association data
-    ttl: 3600           // TTL in seconds
+    usage: 3,     // 0=PKIX-TA, 1=PKIX-EE, 2=DANE-TA, 3=DANE-EE
+    selector: 1,  // 0=Full certificate, 1=SubjectPublicKeyInfo
+    mtype: 1,     // 0=Full data, 1=SHA-256, 2=SHA-512
+    cert: Buffer, // Certificate association data
+    ttl: 3600     // TTL in seconds
 }
 ```
 
-### DANE Usage Types
+### Usage types
 
-| Usage | Name    | Description                                             | Support Status |
-| ----- | ------- | ------------------------------------------------------- | -------------- |
-| 0     | PKIX-TA | CA constraint - must chain to specified CA              | Partial\*      |
-| 1     | PKIX-EE | Service certificate constraint - must match exactly     | Full           |
-| 2     | DANE-TA | Trust anchor assertion - specified cert is trust anchor | Full\*         |
-| 3     | DANE-EE | Domain-issued certificate - certificate must match      | Full           |
+| Usage | Name    | Description                                            | Support |
+| ----- | ------- | ------------------------------------------------------ | ------- |
+| 0     | PKIX-TA | CA constraint, must chain to the specified CA          | Partial |
+| 1     | PKIX-EE | Service certificate constraint, must match exactly     | Full    |
+| 2     | DANE-TA | Trust anchor assertion, specified cert is trust anchor | Full\*  |
+| 3     | DANE-EE | Domain-issued certificate, certificate must match      | Full    |
 
-> **\*Note on DANE-TA and PKIX-TA**: These usage types need the issuer chain, which Node does not pass to a `checkServerIdentity` callback. `createDaneVerifier` accepts an optional `chain` argument (an array of `X509Certificate` objects) to supply it - see [DANE Verification Flow](#dane-verification-flow). Without a chain, only the end-entity certificate is checked and DANE-TA/PKIX-TA records never match.
->
-> The pinned certificate must lie on a signature-verified path from the certificate the server presented. A certificate that merely appears in the chain is not accepted: the trust anchor a TLSA record pins is public, so otherwise anyone could present their own certificate with the pinned CA stapled onto the chain.
->
-> PKIX-TA (usage 0) remains partial: it does not additionally require PKIX path validation to have succeeded ([RFC 7671 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7671#section-5.1)). [RFC 7672 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7672#section-3.1) makes usages 0 and 1 inapplicable to SMTP in any case - for SMTP, prefer DANE-EE (usage 3).
+\* DANE-TA and PKIX-TA need the issuer chain, which Node does not pass to `checkServerIdentity`. Supply it yourself as shown in [Verification flow](#verification-flow). Without a chain, only the end-entity certificate is checked and these records never match.
+
+The pinned certificate must lie on a signature-verified path from the certificate the server presented. A certificate that merely appears in the chain is not accepted: the trust anchor a TLSA record pins is public, so otherwise anyone could staple the pinned CA onto a chain of their own.
+
+PKIX-TA remains partial because it does not additionally require PKIX path validation to have succeeded ([RFC 7671 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7671#section-5.1)). [RFC 7672 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7672#section-3.1) makes usages 0 and 1 inapplicable to SMTP in any case; prefer DANE-EE.
 
 ### Combining DANE with MTA-STS
 
-DANE and MTA-STS can be used together. DANE provides stronger security guarantees (when DNSSEC is properly configured), while MTA-STS provides a fallback for domains that don't support DNSSEC:
+The two work together. DANE gives stronger guarantees where DNSSEC is configured, MTA-STS covers domains without it:
 
 ```javascript
 const connection = await mxConnect({
@@ -309,30 +445,29 @@ const connection = await mxConnect({
         cache: mtaStsCache
     },
     dane: {
-        enabled: true,
-        resolveTlsa: customResolveTlsa,
-        checkDnssecSecure: customCheckDnssecSecure // optional, see DNSSEC-Aware DANE
+        enabled: true
     }
 });
 // Both MTA-STS and DANE checks are performed
 ```
 
-### Accessing DANE Utilities
+### DANE utilities
 
 The DANE module is exported for direct use:
 
 ```javascript
 const { dane } = require('mx-connect');
 
-// Check if native TLSA resolution is available
-console.log('Native TLSA support:', dane.hasNativeResolveTlsa);
+// Is native TLSA resolution available
+console.log(dane.hasNativeResolveTlsa);
 
-// DANE constants
-console.log('DANE Usage Types:', dane.DANE_USAGE);
-console.log('DANE Selectors:', dane.DANE_SELECTOR);
-console.log('DANE Matching Types:', dane.DANE_MATCHING_TYPE);
+// Constants
+console.log(dane.DANE_USAGE, dane.DANE_SELECTOR, dane.DANE_MATCHING_TYPE);
 
-// Verify a certificate against TLSA records (with optional chain for DANE-TA)
+// Resolve TLSA records for a host and port
+const records = await dane.resolveTlsaRecords('mail.example.com', 25, {});
+
+// Verify a certificate against TLSA records, chain optional for DANE-TA
 const result = dane.verifyCertAgainstTlsa(certificate, tlsaRecords, chain);
 ```
 


### PR DESCRIPTION
## Summary

Documentation only. Corrects three claims that no longer match the code, and restructures the parts that had grown into walls of prose.

## The TLSA resolver was documented as something it is not

`dane.resolveTlsa` was presented as a compatibility shim for old Node. That stopped being true when the floor moved to 22.19.0: native `dns.resolveTlsa` landed in **22.15.0**, so every supported version has it, `lib/dane.js` already prefers it automatically, and the option is never required.

Verified against real DANE-enabled hosts with nothing configured:

```
mx1.forwardemail.net  -> 2 TLSA record(s) via the native resolver
mail.ietf.org         -> 1 TLSA record(s) via the native resolver
```

The section also promised "for Node.js versions without native TLSA support", a situation that can no longer arise, and its example passed an **undefined `customResolveTlsa`**, so copying it produced a `ReferenceError`. The same undefined identifier had been pasted into the DNSSEC and MTA-STS examples, where it was noise either way.

The option still has a real purpose, just not that one: routing TLSA lookups through a resolver of your own, usually to obtain the DNSSEC validation Node cannot yet report. It is documented as that now, with a resolver actually written out, and the examples that never needed it no longer carry it.

## Two further mismatches

**The local address precedence was backwards.** The docs said the family-specific options take precedence over `localAddress`. `updateLocalAddressForTarget` does the opposite, confirmed by running it: with `localAddress: '192.0.2.1'` and `localAddressIPv4: '198.51.100.1'` against an IPv4 host, the connection binds **192.0.2.1**. `localAddress` wins whenever it matches the family of the host; the specific options fill in only when it is unset or the host is the other family.

**The Node requirement sat inside the DANE section** although it applies to the whole package. It is stated once at the top now, and the three-row version table is gone because it had collapsed to "every supported version".

## Restructure

Option lists that had grown into paragraphs are tables. Address validation, which had become five dense blocks, is a section of its own with a table per tier: always refused, `blockLocalAddresses`, `blockReservedNetworks`, and the IPv6 forms that carry an IPv4 address. Lists of CIDRs are far easier to scan in a table than in a sentence.

Notes and warnings use GitHub alerts. The two that can actually cost someone a security property are no longer prose buried mid-paragraph:

- a warning that `rejectUnauthorized` must be `false` or a self-signed DANE-EE certificate is rejected by PKIX before the verifier ever runs
- a caution that `connectHook` receives the same options object used to open the socket, so a hook rewriting `options.host` connects wherever it says

## Checks

All nine internal anchors resolve, prettier and lint clean, no code touched.
